### PR TITLE
fix title line lengths in docs build

### DIFF
--- a/docs/source/about/scope.rst
+++ b/docs/source/about/scope.rst
@@ -1,5 +1,5 @@
 Scope of the CollectOSS project
-==========================
+===============================
 
 CollectOSS focuses on collecting data from public git-based code hosting platforms ("Forges") such as GitHub and GitLab. This helps us produce data about the health and sustainability of software projects based on the relevant CHAOSS metrics.
 The data CollectOSS collects covers more than just code contributions and extends to anything that can be derived from forge data, including comments, change reviews, releases, and other project activity or interactions. 

--- a/docs/source/about/toc.rst
+++ b/docs/source/about/toc.rst
@@ -1,5 +1,5 @@
 About CollectOSS
-===========
+================
 This section contains more details about what the CollectOSS project is, including its mission/scope, and what we hope to accomplish.
 
 

--- a/docs/source/deployment/production.rst
+++ b/docs/source/deployment/production.rst
@@ -1,5 +1,5 @@
 Running CollectOSS in Production
-===========================
+================================
 
 This page collects practical tips, configuration notes, and important considerations
 for deploying CollectOSS in a production environment. This is a reference to help

--- a/docs/source/development-guide/tech-breakdown.rst
+++ b/docs/source/development-guide/tech-breakdown.rst
@@ -96,7 +96,7 @@ collection and analysis on the same database. Use of PGBouncer or other
 utility may change these characteristics.
 
 CollectOSS Commands
---------------
+-------------------
 
 To access command line options, use ``collectoss --help``. To load repos from
 GitHub organizations prior to collection, or in other ways, the direct

--- a/docs/source/development-guide/workers/creating_a_new_worker.rst
+++ b/docs/source/development-guide/workers/creating_a_new_worker.rst
@@ -69,7 +69,7 @@ The key sections you can copy from any worker are illustrated in this example fr
             self.data_source = 'GitHub API'
 
 Getting Your Worker to Talk to CollectOSS
-----------------------------------------
+-----------------------------------------
 
 In the house keeper block, you need to add something following this pattern, inside the "jobs" section:
 

--- a/docs/source/getting-started/command-line-interface/backend.rst
+++ b/docs/source/getting-started/command-line-interface/backend.rst
@@ -3,7 +3,7 @@ Backend Commands
 =================
 
 ``collectoss backend``
-====================
+======================
 The ``collectoss backend`` CLI group is for controlling CollectOSS's API server & data collection workers. All commands are invoked like::
 
   $ collectoss backend <command name>

--- a/docs/source/getting-started/command-line-interface/configure.rst
+++ b/docs/source/getting-started/command-line-interface/configure.rst
@@ -3,7 +3,7 @@ Configuration Commands
 =======================
 
 ``collectoss config``
-====================
+=====================
 The ``collectoss config`` commands are for interacting with CollectOSS's configuration file.
 
 ``init``

--- a/docs/source/getting-started/command-line-interface/db.rst
+++ b/docs/source/getting-started/command-line-interface/db.rst
@@ -3,7 +3,7 @@ Database Commands
 ====================
 
 ``collectoss db``
-=============
+=================
 
 The collection of ``collectoss db`` commands is for interacting with the database.
 

--- a/docs/source/getting-started/command-line-interface/logging.rst
+++ b/docs/source/getting-started/command-line-interface/logging.rst
@@ -3,7 +3,7 @@ Logging Commands
 ====================
 
 ``collectoss logging``
-==================
+======================
 
 The collection of the ``collectoss logging`` commands is for interacting with the database.
 

--- a/docs/source/getting-started/using-docker.rst
+++ b/docs/source/getting-started/using-docker.rst
@@ -38,7 +38,7 @@ or
 And collectoss should be up and running! Over time, you may decide that you want to download and run newer releases of CollectOSS. It is critical that your ``.env`` file remains configured to use the same database name and password; though you can change the password if you understand how to connect to a database running inside a Docker container on your computer.
 
 Rebuilding CollectOSS in Docker
-----------------------------
+-------------------------------
 
 To rebuild a fresh CollectOSS database in Docker, follow these steps:
 

--- a/docs/source/login.rst
+++ b/docs/source/login.rst
@@ -1,5 +1,5 @@
 CollectOSS OAuth Flow
-=================
+=====================
 
 CollectOSS implements the Oauth 2.0 specification, and each CollectOSS instance is capable of acting as an authorization server for external applications.
 

--- a/docs/source/procedures/creating-releases.rst
+++ b/docs/source/procedures/creating-releases.rst
@@ -1,5 +1,5 @@
 The CollectOSS Release Process
-=========================
+==============================
 
 The first step to releasing any changes is to have changes in the first place.
 CollectOSS's `CONTRIBUTING.md <https://github.com/chaoss/collectoss/blob/main/CONTRIBUTING.md>`__ file

--- a/docs/source/procedures/toc.rst
+++ b/docs/source/procedures/toc.rst
@@ -1,6 +1,6 @@
-====================================
+========================================
 CollectOSS Standard Operating Procedures
-====================================
+========================================
 
 This section of the documentation is where the various procedures that help the project run smoothly are documented. If you are unsure of why we do things a certain way, or want to get more involved in the process of helping maintain CollectOSS this may be the place for you.
 

--- a/docs/source/schema/regularly_used_data.rst
+++ b/docs/source/schema/regularly_used_data.rst
@@ -1,5 +1,5 @@
 List of Regularly Used Data Tables In CollectOSS
-===========================================
+================================================
 
 **This is a list of data tables in collectoss that are regularly used and the various tasks attached to them.**
 

--- a/docs/source/schema/unused_data.rst
+++ b/docs/source/schema/unused_data.rst
@@ -1,5 +1,5 @@
 List of Unused Data Tables In CollectOSS
-===================================
+========================================
 
 ** This is a list of data tables in collectoss that are not currently in use. **
 

--- a/docs/source/schema/working_tables.rst
+++ b/docs/source/schema/working_tables.rst
@@ -1,5 +1,5 @@
 List of Working Data Tables In CollectOSS
-====================================
+=========================================
 
 **This Is A List of Working Tables In CollectOSS and The Tasks Attached to Them.**
 


### PR DESCRIPTION
**Description**
The docs are failing to build - this PR fixes the syntax issues in the docs that makes them work again

this is basically all just fixes to the lengths of the underlines of the titles because RST is picky about that

**Notes for Reviewers**

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/collectoss/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->