### PR TITLE
Temporarily Return augur_settings table to model

### DIFF
--- a/collectoss/application/db/models/__init__.py
+++ b/collectoss/application/db/models/__init__.py
@@ -96,6 +96,7 @@ from collectoss.application.db.models.spdx import (
 )
 
 from collectoss.application.db.models.augur_operations import (
+    Settings,
     WorkerHistory,
     WorkerJob,
     WorkerOauth,

--- a/collectoss/application/db/models/augur_operations.py
+++ b/collectoss/application/db/models/augur_operations.py
@@ -87,6 +87,26 @@ t_all = Table(
 )
 
 
+class Settings(Base):
+    __tablename__ = "augur_settings"
+    __table_args__ = {
+        "schema": "augur_operations",
+        "comment": "CollectOSS settings include the schema version, and the CollectOSS API Key as of 10/25/2020. Future augur settings may be stored in this table, which has the basic structure of a name-value pair. ",
+    }
+
+    id = Column(
+        BigInteger,
+        Sequence("augur_settings_id_seq", start=1, schema="augur_operations"),
+        primary_key=True,
+        server_default=text(
+            "nextval('augur_operations.augur_settings_id_seq'::regclass)"
+        ),
+    )
+    setting = Column(String)
+    value = Column(String)
+    last_modified = Column(TIMESTAMP(precision=0), server_default=text("CURRENT_DATE"))
+
+
 t_repos_fetch_log = Table(
     "repos_fetch_log",
     metadata,


### PR DESCRIPTION
**Description**

in commit 22d2ed16bb8d02aba2ce4425fe1ef0cc4c88267b (part of #2) the AugurSetting database model class was deleted since it was not used.

I have realized that this table, while not used for live config values to my knowledge, is still used by parts of the CLI fetching the version of the application.

All references to this table in the code need removing before this table can be dropped

This PR returns the table to the models under a slightly different class name (which wasnt being used anywhere so no problems there).

no database migration was done to remove this table so none is needed to reverse this change

**Notes for Reviewers**

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/collectoss/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->