### PR TITLE
Use engine.begin() for DELETE operation

### DIFF
--- a/collectoss/api/routes/util.py
+++ b/collectoss/api/routes/util.py
@@ -27,7 +27,7 @@ def get_all_repo_groups(): #TODO: make this name automatic - wrapper?
         ORDER BY rg_name
     """)
 
-    with current_app.engine.begin() as conn:
+    with current_app.engine.connect() as conn:
         results = pd.read_sql(repoGroupsSQL,  conn)
     data = results.to_json(orient="records", date_format='iso', date_unit='ms')
     return Response(response=data,

--- a/collectoss/api/routes/util.py
+++ b/collectoss/api/routes/util.py
@@ -27,7 +27,7 @@ def get_all_repo_groups(): #TODO: make this name automatic - wrapper?
         ORDER BY rg_name
     """)
 
-    with current_app.engine.connect() as conn:
+    with current_app.engine.begin() as conn:
         results = pd.read_sql(repoGroupsSQL,  conn)
     data = results.to_json(orient="records", date_format='iso', date_unit='ms')
     return Response(response=data,

--- a/collectoss/tasks/data_analysis/insight_worker/tasks.py
+++ b/collectoss/tasks/data_analysis/insight_worker/tasks.py
@@ -106,7 +106,7 @@ def insight_model(repo_git: str,logger,engine) -> None:
                 AND ri_date < :min_date
     """)
 
-    with engine.connect() as conn:
+    with engine.begin() as conn:
         result = conn.execute(delete_record_SQL, parameters=dict(repo_id=repo_id, min_date=min_date))
 
     logger.info("Deleting out of date data points ...\n")


### PR DESCRIPTION
**Description**
This is a change made by @Phanindra899 originally in https://github.com/augurlabs/augur/pull/3799
It has been rebased

This PR updates transaction handling by applying engine.begin() to a data-modifying DELETE query in tasks.py, ensuring proper commit/rollback behavior in line with SQLAlchemy 2.0 semantics.

The previous change applied to a read-only query in util.py has been reverted, as transaction handling is not required for SELECT operations.

The change is intentionally minimal and scoped to a single DELETE operation to ensure safety and ease of review.

This PR contributes to #230 

**Notes for Reviewers**

**Signed commits**
- [X] Yes, I signed my commits. (on behalf of the original author whose commits were signed)

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/collectoss/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->