### PR TITLE
ensure facade checking process always gets rescheduled

### DIFF
--- a/collectoss/tasks/git/facade_tasks.py
+++ b/collectoss/tasks/git/facade_tasks.py
@@ -384,7 +384,7 @@ def clone_repos():
                 setattr(repoStatus,"facade_status", CollectionState.ERROR.value)
                 session.commit()
 
-            clone_repos.si().apply_async(countdown=60*5)
+        clone_repos.si().apply_async(countdown=60*5)
 
 
 #@celery.task(bind=True)


### PR DESCRIPTION
**Description**

This PR is quite literally just the suggested fix in the linked issue (making sure the task always gets rescheduled, even if there are no new facade repos).

Easy one line (one character) change, major usability win for newcomers

fixes #116

**Notes for Reviewers**
Tested on my local instance by adding a new repo after the instance was already up.

Testing quality: more likely than not to work (medium effort)

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/collectoss/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->