### PR TITLE
Add deprecation warnings to functions that should be deprecated

### DIFF
--- a/collectoss/application/db/lib.py
+++ b/collectoss/application/db/lib.py
@@ -9,6 +9,7 @@ from sqlalchemy.dialects import postgresql
 from sqlalchemy.exc import OperationalError
 from psycopg2.errors import DeadlockDetected
 from typing import List, Any, Optional, Union
+from typing_extensions import deprecated
 
 from collectoss.application.db.models import Config, Repo, Commit, WorkerOauth, Issue, PullRequest, PullRequestReview, ContributorsAlias,UnresolvedCommitEmail, Contributor, CollectionStatus, UserGroup, RepoGroup
 from collectoss.tasks.util.collection_state import CollectionState
@@ -18,7 +19,7 @@ from collectoss.application.db.session import remove_duplicates_by_uniques, remo
 
 logger = logging.getLogger("db_lib")
 
-
+@deprecated("This is a legacy method. Use AugurConfig.get_value instead")
 def get_value(section_name: str, setting_name: str) -> Optional[Any]:
     """Get the value of a setting from the config.
 

--- a/collectoss/tasks/git/util/facade_worker/facade_worker/repofetch.py
+++ b/collectoss/tasks/git/util/facade_worker/facade_worker/repofetch.py
@@ -36,6 +36,7 @@ from collectoss.application.db.models.augur_data import *
 from collectoss.application.db.models.augur_operations import CollectionStatus
 from collectoss.application.db.util import execute_session_query, convert_orm_list_to_dict_list
 from collectoss.application.db.lib import execute_sql, get_repo_by_repo_git
+from typing_extensions import deprecated
 
 class GitCloneError(Exception):
     pass
@@ -174,8 +175,7 @@ def git_repo_initialize(facade_helper, session, repo_git):
     facade_helper.log_activity('Info', f"Fetching new repos (complete)")
 
 
-# Deprecated functionality. No longer used
-# Should be re-purposed in start_tasks when tasks are being scheduled
+@deprecated("Deprecated functionality. No longer used. Should be re-purposed in start_tasks when tasks are being scheduled")
 def check_for_repo_updates(session, repo_git):
 
     # Check the last time a repo was updated and if it has been longer than the
@@ -244,7 +244,7 @@ def check_for_repo_updates(session, repo_git):
 
 # Deprecated. No longer used.
 
-
+@deprecated("This functionality is deprecated and won't work with present facade versions")
 def force_repo_updates(session, repo_git):
     raise NotImplementedError(
         "This functionality is deprecated and won't work with present facade versions")
@@ -263,7 +263,7 @@ def force_repo_updates(session, repo_git):
 
 # Deprecated. No longer used.
 
-
+@deprecated("This functionality is deprecated and won't work with present facade versions")
 def force_repo_analysis(session, repo_git):
     raise NotImplementedError(
         "This functionality is deprecated and won't work with present facade versions")

--- a/collectoss/tasks/github/facade_github/contributor_interfaceable/contributor_interface.py
+++ b/collectoss/tasks/github/facade_github/contributor_interfaceable/contributor_interface.py
@@ -8,7 +8,7 @@ from collectoss.tasks.github.util.github_data_access import GithubDataAccess
 # Debugger
 from collectoss.tasks.github.util.github_paginator import GithubApiResult
 from collectoss.application.db.lib import get_repo_by_repo_id, bulk_insert_dicts, execute_sql, get_contributors_by_github_user_id
-
+from typing_extensions import deprecated
 
 ##TODO: maybe have a TaskSession class that holds information about the database, logger, config, etc.
 
@@ -27,7 +27,7 @@ def clean_dict(d):
     return {k: ("" if v is None else v) for k, v in d.items()}
 
 
-# deprecated in favor of GithubDataAcess.get_resource()
+@deprecated("Please use GithubDataAcess.get_resource() instead")
 def request_dict_from_endpoint(logger, session, url, timeout_wait=10):
     """Hit the endpoint specified by the url and return the json that it returns if it returns a dict.
     

--- a/collectoss/tasks/github/util/github_paginator.py
+++ b/collectoss/tasks/github/util/github_paginator.py
@@ -7,8 +7,9 @@ import logging
 
 from typing import Optional
 from enum import Enum
+from typing_extensions import deprecated
 
- 
+@deprecated("Deprecated. Use GithubDataAccess class instead") 
 def hit_api(key_manager, url: str, logger: logging.Logger, timeout: float = 10, method: str = 'GET', follow_redirects=True) -> Optional[httpx.Response]:
     """Ping the api and get the data back for the page.
 

--- a/collectoss/tasks/github/util/github_random_key_auth.py
+++ b/collectoss/tasks/github/util/github_random_key_auth.py
@@ -3,7 +3,9 @@
 from collectoss.tasks.util.random_key_auth import RandomKeyAuth
 from collectoss.tasks.github.util.github_api_key_handler import GithubApiKeyHandler
 from sqlalchemy.orm import Session
+from typing_extensions import deprecated
 
+@deprecated("This class is deprecated. Use the KeyClient interface to the Keymanager process instead.")
 class GithubRandomKeyAuth(RandomKeyAuth):
     """Defines a github specific RandomKeyAuth class so 
     github collections can have a class randomly selects an api key for each request    


### PR DESCRIPTION
**Description**
ported from https://github.com/augurlabs/augur/pull/3788

This uses the typing_extensions library to add the `@deprecated` decorator for some of the older python versions we support and marks several functions as deprecated so peoples editors can highlight them and their uses can be phased out over time.

There were several functions in the repo with deprecations noted in comments, but none were properly marked as deprecated in a way that peoples editors would see.


**Notes for Reviewers**
Needs testing - drafting until i can get to it

This should only affect developers, so as long as the imports dont cause problems on first startup, id consider this ready
**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/collectoss/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->