### PR TITLE
Start consolodating Github REST API URLs into a central place

### DIFF
--- a/collectoss/tasks/data_analysis/contributor_breadth_worker/contributor_breadth_worker.py
+++ b/collectoss/tasks/data_analysis/contributor_breadth_worker/contributor_breadth_worker.py
@@ -92,7 +92,7 @@ def contributor_breadth_model(self) -> None:
         logger.info(f"Processing cntrb {index} of {total}")
         index += 1
 
-        repo_cntrb_url = f"https://api.github.com/users/{cntrb['gh_login']}/events"
+        repo_cntrb_url = github_data_access.endpoint_url(f"users/{cntrb['gh_login']}/events")
 
         newest_event_in_db = datetime(1970, 1, 1)
         if cntrb["gh_login"] in cntrb_newest_events_map:

--- a/collectoss/tasks/github/contributors.py
+++ b/collectoss/tasks/github/contributors.py
@@ -5,6 +5,7 @@ import traceback
 from collectoss.tasks.init.celery_app import celery_app as celery
 from collectoss.tasks.init.celery_app import CoreRepoCollectionTask
 from collectoss.tasks.github.util.github_paginator import hit_api
+from collectoss.tasks.github.util.github_data_access import GithubDataAccess
 from collectoss.tasks.github.facade_github.tasks import *
 from collectoss.application.db.models import Contributor
 from collectoss.application.db.util import execute_session_query
@@ -26,6 +27,8 @@ def process_contributors():
     data_source = "Github API"
 
     key_auth = GithubRandomKeyAuth(logger)
+
+    github_data_access = GithubDataAccess(key_auth, logger)
 
     with get_session() as session:
 
@@ -56,7 +59,7 @@ def process_contributors():
 
         del contributor_dict["_sa_instance_state"]
 
-        url = f"https://api.github.com/users/{contributor_dict['cntrb_login']}" 
+        url = github_data_access.endpoint_url(f"users/{contributor_dict['cntrb_login']}")
 
         try:
             data = retrieve_dict_data(url, key_auth, logger)

--- a/collectoss/tasks/github/detect_move/core.py
+++ b/collectoss/tasks/github/detect_move/core.py
@@ -1,6 +1,7 @@
 from collectoss.tasks.github.util.github_task_session import *
 from collectoss.application.db.models import Repo, CollectionStatus
 from collectoss.tasks.github.util.github_paginator import hit_api
+from collectoss.tasks.github.util.github_data_access import GithubDataAccess
 from collectoss.tasks.github.util.util import get_owner_repo
 from collectoss.tasks.github.util.util import parse_json_response
 from datetime import datetime
@@ -76,7 +77,10 @@ def extract_owner_and_repo_from_endpoint(key_auth, url, logger):
 def ping_github_for_repo_move(session, key_auth, repo, logger,collection_hook='core'):
 
     owner, name = get_owner_repo(repo.repo_git)
-    url = f"https://api.github.com/repos/{owner}/{name}"
+
+    github_data_access = GithubDataAccess(key_auth, logger)
+
+    url = github_data_access.endpoint_url(f"repos/{owner}/{name}")
 
     attempts = 0
     while attempts < 10:

--- a/collectoss/tasks/github/events.py
+++ b/collectoss/tasks/github/events.py
@@ -48,9 +48,10 @@ def collect_events(repo_git: str, full_collection: bool):
 
 def bulk_events_collection_endpoint_contains_all_data(key_auth, logger, owner, repo):
 
-    url = f"https://api.github.com/repos/{owner}/{repo}/issues/events?per_page=100"
-
     github_data_access = GithubDataAccess(key_auth, logger)
+
+    url = github_data_access.endpoint_url(f"repos/{owner}/{repo}/issues/events", {"per_page": "100"})
+
 
     page_count = github_data_access.get_resource_page_count(url)
 
@@ -133,10 +134,10 @@ class BulkGithubEventCollection(GithubEventCollection):
     def _collect_events(self, repo_git: str, key_auth, since):
 
         owner, repo = get_owner_repo(repo_git)
-
-        url = f"https://api.github.com/repos/{owner}/{repo}/issues/events"
             
         github_data_access = GithubDataAccess(key_auth, self._logger)
+
+        url = github_data_access.endpoint_url(f"repos/{owner}/{repo}/issues/events")
 
         for event in github_data_access.paginate_resource(url):
 
@@ -314,7 +315,7 @@ class ThoroughGithubEventCollection(GithubEventCollection):
 
             issue_number = issue["issue_number"]
 
-            event_url = f"https://api.github.com/repos/{owner}/{repo}/issues/{issue_number}/events"
+            event_url = github_data_access.endpoint_url(f"repos/{owner}/{repo}/issues/{issue_number}/events")
             
             try:
 
@@ -377,7 +378,7 @@ class ThoroughGithubEventCollection(GithubEventCollection):
 
             pr_number = pr["gh_pr_number"]
 
-            event_url = f"https://api.github.com/repos/{owner}/{repo}/issues/{pr_number}/events"
+            event_url = github_data_access.endpoint_url(f"repos/{owner}/{repo}/issues/{pr_number}/events")
 
             try:
             

--- a/collectoss/tasks/github/facade_github/core.py
+++ b/collectoss/tasks/github/facade_github/core.py
@@ -51,7 +51,7 @@ def query_github_contributors(logger, key_auth, github_url, tool_source:str, too
             # Need to hit this single contributor endpoint to get extra data including...
             #   `created at`
             #   i think that's it
-            cntrb_url = ("https://api.github.com/users/" + repo_contributor['login'])
+            cntrb_url = github_data_access.endpoint_url(f"users/{repo_contributor['login']}")
 
             
             logger.info("Hitting endpoint: " + cntrb_url + " ...\n")

--- a/collectoss/tasks/github/facade_github/core.py
+++ b/collectoss/tasks/github/facade_github/core.py
@@ -26,12 +26,6 @@ def query_github_contributors(logger, key_auth, github_url, tool_source:str, too
         logger.error(f"Encountered bad url: {github_url}")
         raise e
 
-    # Set the base of the url and place to hold contributors to insert
-    contributors_url = (
-        f"https://api.github.com/repos/{owner}/{name}/" +
-        "contributors?state=all"
-    )
-
     # Get contributors that we already have stored
     #   Set our duplicate and update column map keys (something other than PK) to
     #   check dupicates/needed column updates with
@@ -41,6 +35,9 @@ def query_github_contributors(logger, key_auth, github_url, tool_source:str, too
     duplicate_col_map = {'cntrb_login': 'login'}
 
     github_data_access = GithubDataAccess(key_auth, logger)
+
+    # Set the base of the url and place to hold contributors to insert
+    contributors_url = github_data_access.endpoint_url(f"repos/{owner}/{repo}/contributors", {"state": "all"})
 
     contributor_count = github_data_access.get_resource_count(contributors_url)
 

--- a/collectoss/tasks/github/facade_github/tasks.py
+++ b/collectoss/tasks/github/facade_github/tasks.py
@@ -88,7 +88,7 @@ def process_commit_metadata(logger, auth, contributorQueue, repo_id, platform_id
             # move on to the next contributor
             continue
 
-        url = ("https://api.github.com/users/" + login)
+        url = github_data_access.endpoint_url(f"users/{login}")
 
         try:
             user_data = github_data_access.get_resource(url)

--- a/collectoss/tasks/github/issues.py
+++ b/collectoss/tasks/github/issues.py
@@ -103,13 +103,13 @@ def retrieve_all_issue_data(repo_git: str, logger: logging.Logger, key_auth: Git
 
     logger.info(f"Collecting issues for {owner}/{repo}")
 
-    url = f"https://api.github.com/repos/{owner}/{repo}/issues?state=all"
+    github_data_access = GithubDataAccess(key_auth, logger)
+
+    url = github_data_access.endpoint_url(f"repos/{owner}/{repo}/issues/", {"state":"all"})
 
     if since:
         url += f"&since={since.isoformat()}"
-
-    github_data_access = GithubDataAccess(key_auth, logger)
-
+    
     num_pages = github_data_access.get_resource_page_count(url)
     logger.info(f"{owner}/{repo}: Retrieving {num_pages} pages of issues")
 

--- a/collectoss/tasks/github/messages.py
+++ b/collectoss/tasks/github/messages.py
@@ -64,8 +64,10 @@ def fast_retrieve_all_pr_and_issue_messages(repo_git: str, logger, key_auth, tas
 
     owner, repo = get_owner_repo(repo_git)
 
+    github_data_access = GithubDataAccess(key_auth, logger)
+
     # url to get issue and pull request comments
-    url = f"https://api.github.com/repos/{owner}/{repo}/issues/comments"
+    url = github_data_access.endpoint_url(f"repos/{owner}/{repo}/issues/comments")
 
     if since:
         url += f"?since={since.isoformat()}"
@@ -73,8 +75,6 @@ def fast_retrieve_all_pr_and_issue_messages(repo_git: str, logger, key_auth, tas
     # define logger for task
     logger.info(f"Collecting github comments for {owner}/{repo}")
     
-    github_data_access = GithubDataAccess(key_auth, logger)
-
     message_count = github_data_access.get_resource_count(url)
 
     logger.info(f"{task_name}: Collecting {message_count} github messages")

--- a/collectoss/tasks/github/pull_requests/tasks.py
+++ b/collectoss/tasks/github/pull_requests/tasks.py
@@ -227,10 +227,18 @@ def collect_pull_request_review_comments(repo_git: str, full_collection: bool) -
     """
     owner, repo = get_owner_repo(repo_git)
 
-    review_msg_url = f"https://api.github.com/repos/{owner}/{repo}/pulls/comments"
 
     logger = logging.getLogger(collect_pull_request_review_comments.__name__)
     logger.debug(f"Collecting pull request review comments for {owner}/{repo}")
+
+    tool_source = "Pr review comment task"
+    tool_version = "2.0"
+    data_source = "Github API"
+
+    key_auth = GithubRandomKeyAuth(logger)
+    github_data_access = GithubDataAccess(key_auth, logger)
+
+    review_msg_search_args = {}
 
     repo_id = get_repo_by_repo_git(repo_git).repo_id
 
@@ -240,7 +248,7 @@ def collect_pull_request_review_comments(repo_git: str, full_collection: bool) -
         if last_collected_date:
             # Subtract 2 days to ensure all data is collected
             core_data_last_collected = (last_collected_date - timedelta(days=2)).replace(tzinfo=timezone.utc)
-            review_msg_url += f"?since={core_data_last_collected.isoformat()}"
+            review_msg_search_args['since'] = core_data_last_collected.isoformat()
         else:
             logger.warning(f"core_data_last_collected is NULL for recollection on repo: {repo_git}")
 
@@ -253,13 +261,6 @@ def collect_pull_request_review_comments(repo_git: str, full_collection: bool) -
         logger.debug(f"{owner}/{repo} No PR reviews to collect review comments for")
         return
 
-    tool_source = "Pr review comment task"
-    tool_version = "2.0"
-    data_source = "Github API"
-
-    key_auth = GithubRandomKeyAuth(logger)
-    github_data_access = GithubDataAccess(key_auth, logger)
-
     pr_review_comment_batch_size = get_batch_size()
 
     # Batch processing: accumulate comments until batch size reached, then flush
@@ -267,6 +268,8 @@ def collect_pull_request_review_comments(repo_git: str, full_collection: bool) -
     pr_review_comment_dicts = []
     pr_review_msg_mapping_data = {}
     total_refs_inserted = 0
+
+    review_msg_url = github_data_access.endpoint_url(f"repos/{owner}/{repo}/pulls/comments", review_msg_search_args)
 
     # Single-pass extraction: get both contributor and comment data together
     for comment in github_data_access.paginate_resource(review_msg_url):
@@ -512,7 +515,7 @@ def collect_pull_request_reviews(repo_git: str, full_collection: bool) -> None:
             if index % 100 == 0:
                 logger.debug(f"{owner}/{repo} Processing PR {index + 1} of {pr_count}")
 
-            pr_review_url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}/reviews"
+            pr_review_url = github_data_access.endpoint_url(f"repos/{owner}/{repo}/pulls/{pr_number}/reviews")
 
             try:
                 pr_reviews = list(github_data_access.paginate_resource(pr_review_url))

--- a/collectoss/tasks/github/repo_info/core.py
+++ b/collectoss/tasks/github/repo_info/core.py
@@ -16,11 +16,13 @@ def query_committers_count(key_auth, logger, owner, repo):
 
     data = {}
     logger.info('Querying committers count\n')
-    url = f'https://api.github.com/repos/{owner}/{repo}/contributors?per_page=100'
+
+    github_data_access = GithubDataAccess(key_auth, logger)
+
+    url = github_data_access.endpoint_url(f"/repos/{owner}/{repo}/contributors", {"per_page": 100})
     ## If the repository is empty there are zero committers, and the API returns nothing at all. Response 
     ## header of 200 along with an empty JSON. 
     try: 
-        github_data_access = GithubDataAccess(key_auth, logger)
         try: 
             data = github_data_access.get_resource_count(url) 
         except Exception as e: 
@@ -57,9 +59,10 @@ def get_repo_data(logger, url, response):
 """ 
 def get_repo_data(logger, owner, repo):
 
+    github_data_access = GithubDataAccess(None, logger)
+
     try:
-        url = f'https://api.github.com/repos/{owner}/{repo}'
-        github_data_access = GithubDataAccess(None, logger)
+        url = github_data_access.endpoint_url(f"/repos/{owner}/{repo}")
         result = github_data_access.get_resource(url)
         return result
     except UrlNotFoundException as e:

--- a/collectoss/tasks/github/util/github_data_access.py
+++ b/collectoss/tasks/github/util/github_data_access.py
@@ -35,6 +35,11 @@ class ResourceGoneException(Exception):
         super().__init__(message)
 
 class GithubDataAccess:
+    """Utilities for accessing the GitHub REST API
+    
+    Public facing functions in this class should refrain from returning data in a structure
+    that is derived from githubs API responses to keep all platform-specific parsing here.
+    """
 
     def _base_url(self):
         return "https://api.github.com"

--- a/collectoss/tasks/github/util/github_data_access.py
+++ b/collectoss/tasks/github/util/github_data_access.py
@@ -36,6 +36,9 @@ class ResourceGoneException(Exception):
 
 class GithubDataAccess:
 
+    def _base_url(self):
+        return "https://api.github.com"
+
     def __init__(self, key_manager, logger: logging.Logger, feature="rest"):
     
         self.logger = logger
@@ -61,7 +64,7 @@ class GithubDataAccess:
         if not path.startswith("/"):
             path = "/" + path
 
-        url = "https://api.github.com" + path
+        url = self._base_url() + path
 
         return self.__add_query_params(url, params or {})
 


### PR DESCRIPTION
**Description**
ported from https://github.com/augurlabs/augur/pull/3685 and takes inspiration from other PRs linked within that pr. This  is a step towards resolving #110.

This pr:
- refactors a few commonly reused functions that generate github API URLs (specifically for the issues, contributors, and user endpoints) so that the url building happens within the existing GithubDataAccess class.
- creates a function that brings the fetching of github user API data into this class as well (a model for future plans for the other endpoints)
- creates a user_endpoint_urls function that, given a username, can recreate the urls that the github API responds with. This change compliments #3747.
- creates a currently-unused general-purpose function to generate URLs for querying Github's search API, removing the need to manually assemble the URL in an API-compliant way from clients that use it. clients just provide the query string as it would be typed into githubs search box. This change also enabled some current legacy facade code for doing these searches to be replaced with this general-purpose implementation.

**Notes for Reviewers**
Was tested under the prior repo and collection appears to run smoothly with this PR on my local dev instance, indicating this change doesn't cause breakage.

This depends on #306 merging first and Needs retesting due to the fork, so it is a draft

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->