### PR TITLE
Bypass collecting pull request data when PRs are disabled

### DIFF
--- a/collectoss/tasks/github/facade_github/contributor_interfaceable/contributor_interface.py
+++ b/collectoss/tasks/github/facade_github/contributor_interfaceable/contributor_interface.py
@@ -8,7 +8,7 @@ from collectoss.tasks.github.util.github_data_access import GithubDataAccess
 # Debugger
 from collectoss.tasks.github.util.github_paginator import GithubApiResult
 from collectoss.application.db.lib import get_repo_by_repo_id, bulk_insert_dicts, execute_sql, get_contributors_by_github_user_id
-
+from typing_extensions import deprecated
 
 ##TODO: maybe have a TaskSession class that holds information about the database, logger, config, etc.
 
@@ -107,7 +107,7 @@ def request_dict_from_endpoint(logger, session, url, timeout_wait=10):
 
     return response_data
 
-
+@deprecated("Please use GithubDataAcess.endpoint_url() instead")
 def create_endpoint_from_email(email):
     # Note: I added "+type:user" to avoid having user owned organizations be returned
     # Also stopped splitting per note above.
@@ -117,7 +117,7 @@ def create_endpoint_from_email(email):
 
     return url
 
-
+@deprecated("Please use GithubDataAcess.endpoint_url() instead")
 def create_endpoint_from_commit_sha(logger, commit_sha, repo_id):
     logger.debug(
         f"Trying to create endpoint from commit hash: {commit_sha}")

--- a/collectoss/tasks/github/pull_requests/tasks.py
+++ b/collectoss/tasks/github/pull_requests/tasks.py
@@ -79,6 +79,10 @@ def retrieve_all_pr_data(repo_git: str, logger, key_auth, since): #-> Generator[
 
     github_data_access = GithubDataAccess(key_auth, logger)
 
+    if not github_data_access.check_prs_enabled(owner, repo):
+        logger.info(f"{owner}/{repo}: Pull requests appear to be disabled for this repo. Skipping.")
+        return
+
     num_pages = github_data_access.get_resource_page_count(url)
 
     logger.debug(f"{owner}/{repo}: Retrieving {num_pages} pages of pull requests")

--- a/collectoss/tasks/github/pull_requests/tasks.py
+++ b/collectoss/tasks/github/pull_requests/tasks.py
@@ -75,9 +75,10 @@ def retrieve_all_pr_data(repo_git: str, logger, key_auth, since): #-> Generator[
 
     logger.debug(f"Collecting pull requests for {owner}/{repo}")
 
-    url = f"https://api.github.com/repos/{owner}/{repo}/pulls?state=all&direction=desc&sort=updated"
-
     github_data_access = GithubDataAccess(key_auth, logger)
+
+    search_args = {"state": "all", "direction": "desc", "sort": "updated"}
+    url = github_data_access.endpoint_url(f"repos/{owner}/{repo}/pulls", search_args)
 
     if not github_data_access.check_prs_enabled(owner, repo):
         logger.info(f"{owner}/{repo}: Pull requests appear to be disabled for this repo. Skipping.")

--- a/collectoss/tasks/github/util/github_data_access.py
+++ b/collectoss/tasks/github/util/github_data_access.py
@@ -60,6 +60,22 @@ class GithubDataAccess:
 
         return (100 * (num_pages -1)) + len(data)
 
+    def check_prs_enabled(self, owner: str, repo: str,) -> bool:
+        """
+        Checks whether pull requests are enabled for a repository.
+        Returns False if PRs are disabled (404 on /pulls) and true if there are PRs.
+        """
+
+        url = f"https://api.github.com/repos/{owner}/{repo}/pulls?per_page=1"
+
+        try:
+            self.get_resource_page_count(url)
+            return True
+        except UrlNotFoundException:
+            self.logger.info(f"{owner}/{repo}: Pull requests are disabled. Skipping PR collection.")
+            return False
+
+
     def paginate_resource(self, url):
 
         response = self.make_request_with_retries(url)

--- a/collectoss/tasks/github/util/github_data_access.py
+++ b/collectoss/tasks/github/util/github_data_access.py
@@ -96,7 +96,7 @@ class GithubDataAccess:
         Returns False if PRs are disabled (404 on /pulls) and true if there are PRs.
         """
         try:
-            url = github_data_access.endpoint_url(f"repos/{owner}/{repo}/pulls", {"per_page": "1"})
+            url = self.endpoint_url(f"repos/{owner}/{repo}/pulls", {"per_page": "1"})
             self.get_resource_page_count(url)
             return True
         except UrlNotFoundException:

--- a/collectoss/tasks/github/util/github_data_access.py
+++ b/collectoss/tasks/github/util/github_data_access.py
@@ -5,7 +5,6 @@ from tenacity import retry, stop_after_attempt, wait_fixed, retry_if_exception, 
 from urllib.parse import urlparse, parse_qs, urlencode
 from keyman.KeyClient import KeyClient
 from collectoss.util.keys import mask_key
-import urllib.parse
 
 GITHUB_RATELIMIT_REMAINING_CAP = 50
 
@@ -55,24 +54,16 @@ class GithubDataAccess:
         Returns:
             str: the full URL to the specified resource.
         """
-        # using pythons url processing library this way helps handle accidental
+        # using pythons url processing library helps handle accidental
         # inclusion of query parameters in the path string, ensuring all query
         # parameters are properly encoded and escaped
 
-        input_url_parts = urllib.parse.urlsplit(path)
-        final_query_parameters = dict()
+        if not path.startswith("/"):
+            path = "/" + path
 
-        if input_url_parts.query != '':
-            final_query_parameters.update(
-                parse_qs(input_url_parts.query)
-            )
-        
-        if params != None:
-            final_query_parameters.update(params)
+        url = "https://api.github.com" + path
 
-        return urllib.parse.urlunsplit(
-            ('https', 'api.github.com', input_url_parts.path, urllib.parse.urlencode(final_query_parameters), '')
-        )
+        return self.__add_query_params(url, params or {})
 
     def get_resource_count(self, url):
 

--- a/collectoss/tasks/github/util/github_data_access.py
+++ b/collectoss/tasks/github/util/github_data_access.py
@@ -5,6 +5,7 @@ from tenacity import retry, stop_after_attempt, wait_fixed, retry_if_exception, 
 from urllib.parse import urlparse, parse_qs, urlencode
 from keyman.KeyClient import KeyClient
 from collectoss.util.keys import mask_key
+import urllib.parse
 
 GITHUB_RATELIMIT_REMAINING_CAP = 50
 
@@ -44,6 +45,35 @@ class GithubDataAccess:
         self.key = None
         self.expired_keys_for_request = []
 
+    def endpoint_url(self, path: str, params: dict = None) -> str:
+        """Build a URL for a github endpoint using the specified path and query parameters
+
+        Args:
+            path (str): the path to use (i.e. "/users/MoralCode")
+            params (dict): optional query parameters to add to the url, as a dict
+
+        Returns:
+            str: the full URL to the specified resource.
+        """
+        # using pythons url processing library this way helps handle accidental
+        # inclusion of query parameters in the path string, ensuring all query
+        # parameters are properly encoded and escaped
+
+        input_url_parts = urllib.parse.urlsplit(path)
+        final_query_parameters = dict()
+
+        if input_url_parts.query != '':
+            final_query_parameters.update(
+                parse_qs(input_url_parts.query)
+            )
+        
+        if params != None:
+            final_query_parameters.update(params)
+
+        return urllib.parse.urlunsplit(
+            ('https', 'api.github.com', input_url_parts.path, urllib.parse.urlencode(final_query_parameters), '')
+        )
+
     def get_resource_count(self, url):
 
         # set per_page to 100 explicitly so we know each page is 100 long
@@ -65,10 +95,8 @@ class GithubDataAccess:
         Checks whether pull requests are enabled for a repository.
         Returns False if PRs are disabled (404 on /pulls) and true if there are PRs.
         """
-
-        url = f"https://api.github.com/repos/{owner}/{repo}/pulls?per_page=1"
-
         try:
+            url = github_data_access.endpoint_url(f"repos/{owner}/{repo}/pulls", {"per_page": "1"})
             self.get_resource_page_count(url)
             return True
         except UrlNotFoundException:


### PR DESCRIPTION
**Description**
This PR adds a function to `GithubDataAccess` to enable the status of pull requests to be detected at the start of the PR collection job and short-curcuit if PRs are not enabled, thus avoiding a task failure.

This may only be a PARTIAL FIX for the general case of "things are failing because prs are disabled". I need to disentangle the various issues that have been filed for this.

This PR fixes #229 in the narrow case of pull request collection.

**Notes for Reviewers**

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/collectoss/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->