### PR TITLE
Improve UrlNotFoundException logging context

### DIFF
--- a/collectoss/tasks/data_analysis/contributor_breadth_worker/contributor_breadth_worker.py
+++ b/collectoss/tasks/data_analysis/contributor_breadth_worker/contributor_breadth_worker.py
@@ -113,11 +113,11 @@ def contributor_breadth_model(self) -> None:
             if len(cntrb_events) == 0:
                 logger.info("There are no cntrb events, or new events for this user.\n")
                 continue
-
         except UrlNotFoundException as e:
-            logger.warning(e)
+            logger.warning(
+                f"UrlNotFoundException while processing contributor {cntrb['gh_login']}: {e}"
+            )
             continue
-
         events = process_contributor_events(cntrb, cntrb_events, logger, tool_source, tool_version, data_source)
 
         logger.info(f"Inserting {len(events)} events")


### PR DESCRIPTION
This PR improves warning log clarity in contributor_breadth_worker.py.

Previously, the worker logged raw exception objects using:

logger.warning(e)

This could produce contextless or unclear warning messages during contributor processing.

The updated logging now includes:

* contributor login context
* explicit exception information
* clearer debugging output

No functional logic was changed.