### PR TITLE
[docs] Update README metrics link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ CollectOSS's main focus is to measure the overall health and sustainability of o
 
 The data CollectOSS collects covers more than just code contributions and extends to anything that can be derived from forge data, including comments, change reviews, releases, and other project activity or interactions. This data is stored in a relational database (PostgreSQL), enabling large-scale data aggregation across any number of repositories to provide context about the way these communities evolve.
 
-CollectOSS is part of [CHAOSS](https://chaoss.community), which is a Linux Foundation® project. Many of our metrics are implementations of the [metrics](https://chaoss.community/metrics/) defined by the CHAOSS community.
+CollectOSS is part of [CHAOSS](https://chaoss.community), which is a Linux Foundation® project. Many of our metrics are implementations of the [metrics](https://chaoss.community/kb-metrics-and-metrics-models/) defined by the CHAOSS community.
 
 ## Versions and support
 CollectOSS is a Python project distributed via container images and aims to support all currently-supported versions of Python on macOS and Linux platforms. Docker is the primary supported container runtime, but Podman is also supported and used by some maintainers, although it requires configuring some extra permissions to run correctly.


### PR DESCRIPTION
Summary
- Updates the README CHAOSS metrics link to the current metrics and metrics models knowledge base page.
- Keeps the change limited to the incorrect README URL reported in #317.
- Preserves the surrounding wording and link text.

Validation
- `git diff --check` passed.
- `curl.exe -L -I` returned HTTP 200 for `https://chaoss.community/kb-metrics-and-metrics-models/`.
- `uv lock --check` passed.

Notes
- Fixes #317.
- Compatibility impact: none; documentation-only change.
- Signed commits: yes.