### PR TITLE
inject application name into engine connection args

### DIFF
--- a/collectoss/api/server.py
+++ b/collectoss/api/server.py
@@ -329,7 +329,7 @@ def get_server_cache(cache_manager) -> Cache:
 
 logger = SystemLogger("server").get_logger()
 url = get_database_string()
-engine = create_database_engine(url, poolclass=StaticPool)
+engine = create_database_engine(url, poolclass=StaticPool, connect_args={"application_name": f"collectoss v{code_version} api"})
 db_session = DatabaseSession(logger, engine)
 system_config = SystemConfig(logger, db_session)
 

--- a/collectoss/application/cli/db.py
+++ b/collectoss/application/cli/db.py
@@ -511,7 +511,7 @@ def run_psql_command_in_database(target_type, target):
             database_name = db_config["database_name"]
 
             db_conn_string = f"postgresql+psycopg2://{db_config['user']}:{db_config['password']}@{db_config['host']}:{db_config['port']}/{db_config['database_name']}"
-            engine = s.create_engine(db_conn_string)
+            engine = s.create_engine(db_conn_string, connect_args={"application_name": f"collectoss cli"})
 
     check_call(
         [

--- a/collectoss/application/db/__init__.py
+++ b/collectoss/application/db/__init__.py
@@ -12,7 +12,7 @@ def get_engine():
 
     if engine is None:
         url = get_database_string()
-        engine = create_database_engine(url=url, poolclass=StaticPool)  
+        engine = create_database_engine(url=url, poolclass=StaticPool, connect_args={"application_name": f"collectoss"})  
         Session = sessionmaker(bind=engine)
     
     return engine
@@ -42,7 +42,7 @@ def get_session():
 def temporary_database_engine():
 
     url = get_database_string()
-    temporary_database_engine = create_database_engine(url=url, poolclass=StaticPool)  
+    temporary_database_engine = create_database_engine(url=url, poolclass=StaticPool, connect_args={"application_name": f"collectoss temporary/testing"})  
 
     try:
         yield temporary_database_engine

--- a/conftest.py
+++ b/conftest.py
@@ -14,7 +14,6 @@ from collectoss.application.db.session import DatabaseSession
 from collectoss.application.config import SystemConfig
 from collectoss.application.db.engine import get_database_string, create_database_engine, parse_database_string, execute_sql_file
 
-
 logger = logging.getLogger(__name__)
 
 default_repo_id = "25430"
@@ -104,7 +103,8 @@ def generate_db_from_template(template_name):
     create_database(conn, cursor, test_db_name, template_name)
 
     # create engine to connect to db
-    engine = create_database_engine(test_db_string, poolclass=StaticPool)
+    engine = create_database_engine(test_db_string, poolclass=StaticPool, connect_args={"application_name": f"collectoss tests"})
+
 
     yield engine
 


### PR DESCRIPTION
based on https://stackoverflow.com/questions/15685861/setting-application-name-on-postgres-sqlalchemy

When diagnosing #248, i investigated the seemingly high number of idle postgres tasks. while confirming whether these were a problem, i used dbeaver to view the open sessions on the database. This view in dbeaver has a column for application name (a couple of which were populated with dbeavers own name, for its own db connections).

I think setting collectoss to identify its own connections this way ( which can be done using https://stackoverflow.com/questions/15685861/setting-application-name-on-postgres-sqlalchemy) is a small change that can would help debugging efforts, especially when multiple things (grafana stack, collectoss, dbeaver or other user-preferred database tools, researchers) can be accessing the collectoss database at a time. This may also lightly help debug our "connection leaks" issue (#148 etc)

This PR adds the string `collectoss` to this field by passing it as a connection argument when we create a database engine.

This string may also be followed by some other text indicating which part of collectoss the database connections are coming from (such as api, cli, etc). While I initially tried to include the version number, This turned out to not be possible as testing revealed that the `metadata` file this version is in is not an actual module that is accessible

**Notes for Reviewers**
Was tested previously

**Signed commits**
- [X] Yes, I signed my commits.
