### PR TITLE
provide new repo name when updating a repo URL in move detection

### DIFF
--- a/collectoss/tasks/github/detect_move/core.py
+++ b/collectoss/tasks/github/detect_move/core.py
@@ -110,7 +110,7 @@ def ping_github_for_repo_move(session, key_auth, repo, logger,collection_hook='c
         repo_update_dict = {
             'repo_git': f"https://github.com/{owner}/{name}",
             'repo_path': None,
-            'repo_name': None,
+            'repo_name': name,
             'description': f"(Originally hosted at {url}) {old_description}"
         }
 


### PR DESCRIPTION
**Description**
This PR fixes #310

**Notes for Reviewers**
Have yet to test, testing should be pretty easy though:
1. build and run the latest version
2. add a repo that is known to have moved elsewhere
3. verify that the old name is present in the DB repo table as soon as it is added
4. wait for the move detection task to complete and verify that the new name is now present.
5. ensure collection goes fully

marking draft until i can test this

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
7. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/collectoss/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->