### PR TITLE
Skip comments that return a 410 Gone error from github as well.

### DIFF
--- a/collectoss/tasks/github/messages.py
+++ b/collectoss/tasks/github/messages.py
@@ -4,7 +4,7 @@ from datetime import timedelta, timezone
 from collectoss.tasks.init.celery_app import celery_app as celery
 from collectoss.tasks.init.celery_app import CoreRepoCollectionTask
 from collectoss.application.db.data_parse import *
-from collectoss.tasks.github.util.github_data_access import GithubDataAccess, UrlNotFoundException
+from collectoss.tasks.github.util.github_data_access import GithubDataAccess, UrlNotFoundException, ResourceGoneException
 from collectoss.tasks.github.util.github_task_session import GithubTaskManifest
 from collectoss.tasks.util.worker_util import remove_duplicate_dicts
 from collectoss.tasks.github.util.util import get_owner_repo
@@ -126,6 +126,9 @@ def process_large_issue_and_pr_message_collection(repo_id, repo_git: str, logger
             all_data += messages
         except UrlNotFoundException:
             logger.info(f"{task_name}: PR or issue comment url of {comment_url} returned 404. Skipping.")
+            skipped_urls += 1
+        except ResourceGoneException:
+            logger.info(f"{task_name}: PR or issue comment url of {comment_url} returned 410. Skipping.")
             skipped_urls += 1
 
         if len(all_data) >= message_batch_size:


### PR DESCRIPTION
**Description**
This includes a catch case for 410 GONE replies from github (as would appear in the comments endpoint when trying to fetch comments on issues where issues are disabled repo wide.

This PR fixes #226

**Notes for Reviewers**
Draft until fully tested

Target testing level: Manual Functional test

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/collectoss/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->