### PR TITLE
docs: remove reference to nonexistent database-compose.yml

### DIFF
--- a/docs/source/docker/docker-compose.rst
+++ b/docs/source/docker/docker-compose.rst
@@ -50,7 +50,7 @@ To run CollectOSS **with** the database container:
 
 .. code-block:: bash
 
-    docker compose -f docker-compose.yml -f database-compose.yml up
+    docker compose up
 
 
 Stopping the containers


### PR DESCRIPTION
## What problem does this solve?
Removes a reference to a nonexistent `database-compose.yml` file in the Docker Compose documentation. The database service is already included in `docker-compose.yml`, so `docker compose up` is sufficient. Closes #333.

## What changed and why?
- Changed line 53 in `docs/source/docker/docker-compose.rst` from:
  `docker compose -f docker-compose.yml -f database-compose.yml up`
  to:
  `docker compose up`

## How was this tested?
- Verified `database-compose.yml` does not exist in the repository
- Verified `docker-compose.yml` already includes a `database` service

## Checklist
- [x] Read CONTRIBUTING.md
- [x] Changes match project coding style
- [x] DCO sign-off added (`-s` flag used on commit)
- [x] Only the documented fix changed (1 line)

---
*This contribution was created with AI assistance, with human review and approval at each step.*
