### PR TITLE
docs(docker): remove reference to nonexistent database-compose.yml

### DIFF
--- a/docs/source/docker/docker-compose.rst
+++ b/docs/source/docker/docker-compose.rst
@@ -50,7 +50,7 @@ To run CollectOSS **with** the database container:
 
 .. code-block:: bash
 
-    docker compose -f docker-compose.yml -f database-compose.yml up
+    docker compose up
 
 
 Stopping the containers


### PR DESCRIPTION
## What problem does this solve?
Updates the docker-compose documentation to remove a reference to `database-compose.yml`, a file that no longer exists in the repository. The Docker Compose setup now includes all services (including database) directly in `docker-compose.yml`, so running `docker compose up` is sufficient. Closes #333.

## What changed and why?
- Removed `-f database-compose.yml` flag from the "with database container" example in docs/source/docker/docker-compose.rst
- The file `database-compose.yml` has not existed for some time, making this reference misleading to contributors

## How was this tested?
- Verified `docker-compose.yml` exists and contains the database service definition
- No `database-compose.yml` file exists in the repository

## Checklist
- [x] Read CONTRIBUTING.md
- [x] Changes match project coding style
- [x] No test needed (documentation-only change)
- [x] CI tool verified: docs build command identified as `make docs`

---
*This contribution was created with AI assistance, with human review and approval at each step.*
