### PR TITLE
Update CollectOSS documentation URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ These resources are a great way to meet the people behind the project, ask quest
 
 ## Learn about the project
 
-If you aren't already familiar with what CollectOSS is, please make sure you've read the [README](README.md) to get a primer on our project, and maybe take a look around the [documentation](https://collectoss.readthedocs.io/en/release/) so you know what we are about. You can also hang out in Slack or join our community meetings to learn more about what we do.
+If you aren't already familiar with what CollectOSS is, please make sure you've read the [README](README.md) to get a primer on our project, and maybe take a look around the [documentation](https://docs.collectoss.org/en/latest/) so you know what we are about. You can also hang out in Slack or join our community meetings to learn more about what we do.
 
 ## Opening an issue
 If you're experiencing an issue with CollectOSS you can search for your problem or question on our [issues](https://github.com/chaoss/collectoss/issues) page to see if someone else has already reported it. If you cannot find your issue, please feel free to [open a new one](https://github.com/chaoss/collectoss/issues/new/choose).
@@ -53,7 +53,7 @@ Github has an article called [Syncing a fork](https://docs.github.com/en/pull-re
 
 ## Helpful Links
 
-- [CollectOSS stable documentation](https://collectoss.readthedocs.io/en/release/)
+- [CollectOSS stable documentation](https://docs.collectoss.org/en/latest/)
 - [CHAOSS Getting Started page](https://chaoss.community/kb-getting-started/)
 
 **Git & GitHub**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ These resources are a great way to meet the people behind the project, ask quest
 
 ## Learn about the project
 
-If you aren't already familiar with what CollectOSS is, please make sure you've read the [README](README.md) to get a primer on our project, and maybe take a look around the [documentation](https://docs.collectoss.org/en/latest/) so you know what we are about. You can also hang out in Slack or join our community meetings to learn more about what we do.
+If you aren't already familiar with what CollectOSS is, please make sure you've read the [README](README.md) to get a primer on our project, and maybe take a look around the [documentation](https://docs.collectoss.org/en/release/) so you know what we are about. You can also hang out in Slack or join our community meetings to learn more about what we do.
 
 ## Opening an issue
 If you're experiencing an issue with CollectOSS you can search for your problem or question on our [issues](https://github.com/chaoss/collectoss/issues) page to see if someone else has already reported it. If you cannot find your issue, please feel free to [open a new one](https://github.com/chaoss/collectoss/issues/new/choose).
@@ -53,7 +53,7 @@ Github has an article called [Syncing a fork](https://docs.github.com/en/pull-re
 
 ## Helpful Links
 
-- [CollectOSS stable documentation](https://docs.collectoss.org/en/latest/)
+- [CollectOSS stable documentation](https://docs.collectoss.org/en/release/)
 - [CHAOSS Getting Started page](https://chaoss.community/kb-getting-started/)
 
 **Git & GitHub**

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Basic initial setup can be completed in a few minutes as follows:
 3. Copy the `environment.txt` file to a new file called `.env` and fill in values for the required variables
 4. Run `docker compose up` to start the containers
 
-Check out the [CollectOSS Documentation](https://collectoss.readthedocs.io) for more detailed setup instructions and troubleshooting steps.
+Check out the [CollectOSS Documentation](https://docs.collectoss.org) for more detailed setup instructions and troubleshooting steps.
 
 ## Contributing
 We strongly believe that communities are what makes open source so impactful. We invite you to join our community, regardless of your experience level or coding abilities! 

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -22,7 +22,7 @@ FROM python:3.11-slim-bullseye
 LABEL org.opencontainers.image.authors="CHAOSS https://chaoss.community"
 LABEL org.opencontainers.image.licenses="MIT"
 LABEL org.opencontainers.image.source="https://github.com/chaoss/collectoss"
-LABEL org.opencontainers.image.documentation="https://collectoss.readthedocs.io"
+LABEL org.opencontainers.image.documentation="https://docs.collectoss.org"
 
 ARG VERSION
 LABEL org.opencontainers.image.version=${VERSION}

--- a/docker/database/Dockerfile
+++ b/docker/database/Dockerfile
@@ -4,7 +4,7 @@ FROM postgres:16
 LABEL org.opencontainers.image.authors="CHAOSS https://chaoss.community"
 LABEL org.opencontainers.image.licenses="MIT"
 LABEL org.opencontainers.image.source="https://github.com/chaoss/collectoss"
-LABEL org.opencontainers.image.documentation="https://collectoss.readthedocs.io"
+LABEL org.opencontainers.image.documentation="https://docs.collectoss.org"
 
 ARG VERSION
 LABEL org.opencontainers.image.version=${VERSION}

--- a/docker/keyman/Dockerfile
+++ b/docker/keyman/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.11.12-alpine
 LABEL org.opencontainers.image.authors="CHAOSS https://chaoss.community"
 LABEL org.opencontainers.image.licenses="MIT"
 LABEL org.opencontainers.image.source="https://github.com/chaoss/collectoss"
-LABEL org.opencontainers.image.documentation="https://collectoss.readthedocs.io"
+LABEL org.opencontainers.image.documentation="https://docs.collectoss.org"
 
 ARG VERSION
 LABEL org.opencontainers.image.version=${VERSION}

--- a/docker/rabbitmq/Dockerfile
+++ b/docker/rabbitmq/Dockerfile
@@ -3,7 +3,7 @@ FROM rabbitmq:4.1-management-alpine
 LABEL org.opencontainers.image.authors="CHAOSS https://chaoss.community"
 LABEL org.opencontainers.image.licenses="MIT"
 LABEL org.opencontainers.image.source="https://github.com/chaoss/collectoss"
-LABEL org.opencontainers.image.documentation="https://collectoss.readthedocs.io"
+LABEL org.opencontainers.image.documentation="https://docs.collectoss.org"
 
 ARG VERSION
 LABEL org.opencontainers.image.version=${VERSION}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ collectoss = "collectoss.application.cli._multicommand:run"
 
 [project.urls]
 Homepage = "https://github.com/chaoss/collectoss"
-Documentation = "https://collectoss.readthedocs.io/en/latest/"
+Documentation = "https://docs.collectoss.org/en/latest/"
 
 
 ############################################################

--- a/scripts/docker/config.sh
+++ b/scripts/docker/config.sh
@@ -43,7 +43,7 @@ function get_github_api_key() {
     echo
     echo "Please provide a valid GitHub API key."
     echo "For more information on how to create the key, visit:"
-    echo "https://collectoss.readthedocs.io/en/latest/getting-started/installation.html#backend"
+    echo "https://docs.collectoss.org/en/latest/getting-started/collecting-data.html"
     echo "** This is required for CollectOSS to gather data ***"
     read -p "GitHub API Key: " github_api_key
     blank_confirm github_api_key
@@ -63,7 +63,7 @@ function get_gitlab_api_key() {
     echo
     echo "Please provide a valid GitLab API key."
     echo "For more information on how to create the key, visit:"
-    echo "https://collectoss.readthedocs.io/en/latest/getting-started/installation.html#backend"
+    echo "https://docs.collectoss.org/en/latest/getting-started/collecting-data.html"
     echo "** This is required for CollectOSS to gather data ***"
     read -p "GitLab API Key: " gitlab_api_key
     blank_confirm gitlab_api_key


### PR DESCRIPTION
## Summary

Closes #340.

Updates references from `collectoss.readthedocs.io` to `docs.collectoss.org`. I also pointed the existing CLI help links at live pages on the new docs domain where the old paths returned 404.

## Verification

- `rg -n "collectoss\.readthedocs\.io"` returns no matches
- `https://docs.collectoss.org/en/latest/` returns HTTP 200
- `https://docs.collectoss.org/en/latest/getting-started/collecting-data.html` returns HTTP 200

## Commit comment

This commit replaces the old Read the Docs host with docs.collectoss.org and points CLI help text to live documentation pages.
