### PR TITLE
add unit tests for check swapped emails function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,8 +146,7 @@ addopts = "-ra -s"
 testpaths = [
     "tests/test_classes",
     "tests/test_application/test_cli/test_csv_utils.py",
-    "tests/test_tasks/test_task_utilities/test_util/test_worker_util.py",
-    "tests/test_tasks/test_task_utilities/test_util/test_contributor_uuid.py",
+    "tests/test_tasks/test_task_utilities/test_util/",
     # "tests/test_routes", # runs, but needs a fixture for connecting to the web interface of Augur
     # "tests/test_metrics",
     # "tests/test_tasks",

--- a/tests/test_tasks/test_task_utilities/test_util/test_check_swapped_emails.py
+++ b/tests/test_tasks/test_task_utilities/test_util/test_check_swapped_emails.py
@@ -1,0 +1,34 @@
+import pytest
+from collectoss.tasks.git.util.facade_worker.facade_worker.analyzecommit import check_swapped_emails
+
+def test_correct_input_unchanged():
+    name, email = check_swapped_emails("John Smith", "john@gmail.com")
+    assert name == "John Smith"
+    assert email == "john@gmail.com"
+
+def test_swapped_input_is_corrected():
+    name, email = check_swapped_emails("john@gmail.com", "John Smith")
+    assert name == "John Smith"
+    assert email == "john@gmail.com"
+
+def test_name_field_contains_mixed_name_and_email():
+    # name field has both a name and email mixed together
+    name, email = check_swapped_emails("John Smith john@gmail.com", "")
+    assert name == "John Smith john@gmail.com"
+    assert email == ""
+
+def test_email_field_contains_mixed_name_and_email():
+    # email field has both a name and email mixed together
+    name, email = check_swapped_emails("John Smith", "John Smith john@gmail.com")
+    assert name == "John Smith"
+    assert email == "John Smith john@gmail.com"
+
+def test_both_fields_contain_mixed_name_and_email():
+    name, email = check_swapped_emails("John Smith john@gmail.com", "Jane Doe jane@gmail.com")
+    assert name == "John Smith john@gmail.com"
+    assert email == "Jane Doe jane@gmail.com"
+
+def test_when_both_empty_strings():
+    name, email = check_swapped_emails("", "")
+    assert name == ""
+    assert email == ""

--- a/tests/test_tasks/test_task_utilities/test_util/test_check_swapped_emails.py
+++ b/tests/test_tasks/test_task_utilities/test_util/test_check_swapped_emails.py
@@ -14,8 +14,8 @@ def test_swapped_input_is_corrected():
 def test_name_field_contains_mixed_name_and_email():
     # name field has both a name and email mixed together
     name, email = check_swapped_emails("John Smith john@gmail.com", "")
-    assert name == "John Smith john@gmail.com"
-    assert email == ""
+    assert name == ""
+    assert email == "John Smith john@gmail.com"
 
 def test_email_field_contains_mixed_name_and_email():
     # email field has both a name and email mixed together


### PR DESCRIPTION
**Description**
This change has been ported from github.com/augurlabs/augur/pull/3777 and was originally started by @Inengs 

it adds a new unit test for a small utility function. I had to correct the logic for one test but it otherwise works

**Notes for Reviewers**

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/collectoss/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->