### PR TITLE
mark functions related to weight-based scheduling as deprecated

### DIFF
--- a/collectoss/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
+++ b/collectoss/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
@@ -35,6 +35,7 @@ from collectoss.tasks.util.worker_util import calculate_date_weight_from_timesta
 from collectoss.application.db.lib import execute_sql, fetchall_data_from_sql_text, remove_working_commits_by_repo_id_and_hashes, remove_commits_by_repo_id_and_hashes, get_repo_by_repo_git, get_session
 from collectoss.application.db.util import execute_session_query
 #from collectoss.tasks.git.util.facade_worker.facade
+from typing_extensions import deprecated
 
 def update_repo_log(logger, facade_helper, repos_id,status):
 
@@ -176,6 +177,7 @@ def get_repo_commit_count(logger, facade_helper, repo_git):
 
 	return commit_count
 
+@deprecated("This method of scheduling is legacy and should be removed")
 def get_facade_weight_time_factor(repo_git):
 
 	with get_session() as session:
@@ -194,15 +196,16 @@ def get_facade_weight_time_factor(repo_git):
 
 		return  time_factor
 
+@deprecated("This method of scheduling is legacy and should be removed")
 def get_facade_weight_with_commit_count(repo_git, commit_count):
 	return commit_count - get_facade_weight_time_factor(repo_git)
 
-
+@deprecated("This method of scheduling is legacy and should be removed")
 def get_repo_weight_by_commit(logger, repo_git):
 	facade_helper = FacadeHelper(logger)
 	return get_repo_commit_count(logger, facade_helper, repo_git) - get_facade_weight_time_factor(repo_git)
 	
-
+@deprecated("This method of scheduling is legacy and should be removed")
 def update_facade_scheduling_fields(repo_git, weight, commit_count):
 
 	repo = get_repo_by_repo_git(repo_git)

--- a/collectoss/tasks/github/util/util.py
+++ b/collectoss/tasks/github/util/util.py
@@ -8,6 +8,7 @@ from collectoss.tasks.github.util.github_random_key_auth import GithubRandomKeyA
 from collectoss.tasks.github.util.github_graphql_data_access import GithubGraphQlDataAccess
 from collectoss.application.db.lib import get_repo_by_repo_git
 from collectoss.tasks.util.worker_util import calculate_date_weight_from_timestamps
+from typing_extensions import deprecated
 
 def get_repo_src_id(owner, repo, logger):
     
@@ -87,6 +88,7 @@ def parse_json_response(logger: logging.Logger, response: httpx.Response) -> dic
         logger.warning(f"invalid return. Response was: {response.text}. Exception: {e}")
         return json.loads(json.dumps(response.text))
 
+@deprecated("This method of scheduling is legacy and should be removed")
 def get_repo_weight_by_issue(logger,repo_git):
     """
     Retrieve the sum of the number of issues and prs in a repository from a graphql query.
@@ -111,6 +113,7 @@ def get_repo_weight_by_issue(logger,repo_git):
     return number_of_issues_and_prs
 
 #Get the weight for each repo for the core collection hook
+@deprecated("This method of scheduling is legacy and should be removed")
 def get_repo_weight_core(logger,repo_git):
     
     repo = get_repo_by_repo_git(repo_git)

--- a/collectoss/tasks/util/collection_util.py
+++ b/collectoss/tasks/util/collection_util.py
@@ -17,7 +17,7 @@ from collectoss.tasks.util.worker_util import calculate_date_weight_from_timesta
 from collectoss.tasks.util.collection_state import CollectionState
 from collectoss.application.db.session import DatabaseSession
 from collectoss.application.config import SystemConfig
-
+from typing_extensions import deprecated
 
 class CollectionRequest:
     def __init__(self,name,phases,max_repo = 10,days_until_collect_again = 1, gitlab_phases=None):
@@ -252,6 +252,7 @@ def core_task_success_util(self, repo_git):
         issue_pr_task_update_weight_util([int(raw_count)],repo_git=repo_git,session=session)
 
 #Update the existing core and secondary weights as well as the raw sum of issues and prs
+@deprecated("This method of scheduling is legacy and should be removed")
 def update_issue_pr_weights(logger,session,repo_git,raw_sum):
     repo = Repo.get_by_repo_git(session, repo_git)
     status = repo.collection_status[0]

--- a/collectoss/tasks/util/worker_util.py
+++ b/collectoss/tasks/util/worker_util.py
@@ -11,6 +11,7 @@ from datetime import datetime
 import json
 import subprocess
 
+from typing_extensions import deprecated
 from collectoss.tasks.util.metadata_exception import MetadataException
 
 
@@ -109,6 +110,7 @@ def remove_duplicate_naturals(data, natural_keys):
 def date_weight_factor(days_since_last_collection,domain_shift=0):
     return (days_since_last_collection - domain_shift) ** 4
 
+@deprecated("This method of scheduling is legacy and should be removed")
 def calculate_date_weight_from_timestamps(added,last_collection,domain_start_days=30):
     #Get the time since last collection as well as when the repo was added.
     if last_collection is None:


### PR DESCRIPTION
**Description**
The codebase still includes code for a legacy system of scheduling where "weights" for each repo are calculated and stored. 

This PR marks these functions as deprecated in preparation for future removal efforts as part of #106 

**Notes for Reviewers**

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/collectoss/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->