### PR TITLE
docs: update docs links to new docs.collectoss.org URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ These resources are a great way to meet the people behind the project, ask quest
 
 ## Learn about the project
 
-If you aren't already familiar with what CollectOSS is, please make sure you've read the [README](README.md) to get a primer on our project, and maybe take a look around the [documentation](https://collectoss.readthedocs.io/en/release/) so you know what we are about. You can also hang out in Slack or join our community meetings to learn more about what we do.
+If you aren't already familiar with what CollectOSS is, please make sure you've read the [README](README.md) to get a primer on our project, and maybe take a look around the [documentation](https://docs.collectoss.org/en/release/) so you know what we are about. You can also hang out in Slack or join our community meetings to learn more about what we do.
 
 ## Opening an issue
 If you're experiencing an issue with CollectOSS you can search for your problem or question on our [issues](https://github.com/chaoss/collectoss/issues) page to see if someone else has already reported it. If you cannot find your issue, please feel free to [open a new one](https://github.com/chaoss/collectoss/issues/new/choose).
@@ -53,7 +53,7 @@ Github has an article called [Syncing a fork](https://docs.github.com/en/pull-re
 
 ## Helpful Links
 
-- [CollectOSS stable documentation](https://collectoss.readthedocs.io/en/release/)
+- [CollectOSS stable documentation](https://docs.collectoss.org/en/release/)
 - [CHAOSS Getting Started page](https://chaoss.community/kb-getting-started/)
 
 **Git & GitHub**

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Basic initial setup can be completed in a few minutes as follows:
 3. Copy the `environment.txt` file to a new file called `.env` and fill in values for the required variables
 4. Run `docker compose up` to start the containers
 
-Check out the [CollectOSS Documentation](https://collectoss.readthedocs.io) for more detailed setup instructions and troubleshooting steps.
+Check out the [CollectOSS Documentation](https://docs.collectoss.org) for more detailed setup instructions and troubleshooting steps.
 
 ## Contributing
 We strongly believe that communities are what makes open source so impactful. We invite you to join our community, regardless of your experience level or coding abilities! 


### PR DESCRIPTION
## What problem does this solve?
Updates all documentation links from the old `collectoss.readthedocs.io` domain to the new `docs.collectoss.org` domain. The project purchased `collectoss.org` as a central identity and the docs have been migrated. Closes #340.

## What changed and why?
- README.md line 28: `collectoss.readthedocs.io` → `docs.collectoss.org`
- CONTRIBUTING.md line 12: `collectoss.readthedocs.io/en/release/` → `docs.collectoss.org/en/release/`
- CONTRIBUTING.md line 56: `collectoss.readthedocs.io/en/release/` → `docs.collectoss.org/en/release/`

## How was this tested?
- Searched entire repo for `collectoss.readthedocs.io` — all 3 occurrences updated, 0 remaining

## Checklist
- [x] Read CONTRIBUTING.md
- [x] Changes match project doc style
- [x] No test needed (documentation-only change)
- [x] CI tool verified: make docs

---
*This contribution was created with AI assistance, with human review and approval at each step.*
