### PR TITLE
implement timestamp correction utilities and tests for git commit data

### DIFF
--- a/collectoss/application/db/lib.py
+++ b/collectoss/application/db/lib.py
@@ -1,10 +1,8 @@
-import re
 import time
 import random
 import logging
 import sqlalchemy as s
-from sqlalchemy import func 
-from sqlalchemy.exc import DataError
+from sqlalchemy import func
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.exc import OperationalError
 from psycopg2.errors import DeadlockDetected
@@ -162,7 +160,7 @@ def get_working_commits_by_repo_id(repo_id):
 
     try:
         working_commits = fetchall_data_from_sql_text(query)
-    except:
+    except Exception:
         working_commits = []
 
     return working_commits
@@ -178,7 +176,7 @@ def get_missing_commit_message_hashes(repo_id):
 
     try:
         missing_commit_hashes = fetchall_data_from_sql_text(fetch_missing_hashes_sql)
-    except:
+    except Exception:
         missing_commit_hashes = []
     
     return missing_commit_hashes

--- a/collectoss/application/db/lib.py
+++ b/collectoss/application/db/lib.py
@@ -10,8 +10,10 @@ from typing import List, Any, Optional, Union
 from typing_extensions import deprecated
 
 from collectoss.application.db.models import Config, Repo, Commit, WorkerOauth, Issue, PullRequest, PullRequestReview, ContributorsAlias,UnresolvedCommitEmail, Contributor, CollectionStatus, UserGroup, RepoGroup
+# TODO: CollectionState should be moved to augur/application/db/ to eliminate
+# this cross-layer dependency — same issue as the correction.py import above.
 from collectoss.tasks.util.collection_state import CollectionState
-from collectoss.tasks.git.correction import correct_timestamp
+from collectoss.db.timestamp_utils import correct_timestamp
 from collectoss.application.db import get_session, get_engine
 from collectoss.application.db.util import execute_session_query, convert_type_of_value
 from collectoss.application.db.session import remove_duplicates_by_uniques, remove_null_characters_from_list_of_dicts

--- a/collectoss/application/db/lib.py
+++ b/collectoss/application/db/lib.py
@@ -13,7 +13,7 @@ from collectoss.application.db.models import Config, Repo, Commit, WorkerOauth, 
 # TODO: CollectionState should be moved to augur/application/db/ to eliminate
 # this cross-layer dependency — same issue as the correction.py import above.
 from collectoss.tasks.util.collection_state import CollectionState
-from collectoss.db.timestamp_utils import correct_timestamp
+from collectoss.application.db.timestamp_utils import correct_timestamp
 from collectoss.application.db import get_session, get_engine
 from collectoss.application.db.util import execute_session_query, convert_type_of_value
 from collectoss.application.db.session import remove_duplicates_by_uniques, remove_null_characters_from_list_of_dicts

--- a/collectoss/application/db/lib.py
+++ b/collectoss/application/db/lib.py
@@ -13,6 +13,7 @@ from typing_extensions import deprecated
 
 from collectoss.application.db.models import Config, Repo, Commit, WorkerOauth, Issue, PullRequest, PullRequestReview, ContributorsAlias,UnresolvedCommitEmail, Contributor, CollectionStatus, UserGroup, RepoGroup
 from collectoss.tasks.util.collection_state import CollectionState
+from collectoss.tasks.git.correction import correct_timestamp
 from collectoss.application.db import get_session, get_engine
 from collectoss.application.db.util import execute_session_query, convert_type_of_value
 from collectoss.application.db.session import remove_duplicates_by_uniques, remove_null_characters_from_list_of_dicts
@@ -218,46 +219,30 @@ def facade_bulk_insert_commits(logger, records):
                 facade_bulk_insert_commits(logger, firsthalfRecords)
                 facade_bulk_insert_commits(logger, secondhalfRecords)
             elif len(records) == 1:
+                # Binary search isolated the problematic record
+                # Try to fix invalid timestamps (rare but possible from git corruption)
                 commit_record = records[0]
-                #replace incomprehensible dates with epoch.
-                #2021-10-11 11:57:46 -0500
-                
-                # placeholder_date = "1970-01-01 00:00:15 -0500"
-                placeholder_date = commit_record['cmt_author_timestamp']
 
-                postgres_valid_timezones = {
-                    -1200, -1100, -1000, -930, -900, -800, -700,
-                    -600, -500, -400, -300, -230, -200, -100, 000,
-                    100, 200, 300, 330, 400, 430, 500, 530, 545, 600,
-                    630, 700, 800, 845, 900, 930, 1000, 1030, 1100, 1200,
-                    1245, 1300, 1400
-                }
-                
-                # Reconstruct timezone portion of the date string to UTC
-                placeholder_date_segments = re.split(" ", placeholder_date)
-                tzdata = placeholder_date_segments.pop()
+                # Correct both author and committer timestamps
+                author_corrected = correct_timestamp(
+                    commit_record.get('cmt_author_timestamp', ''),
+                    fallback=None,
+                    logger=logger
+                )
+                committer_corrected = correct_timestamp(
+                    commit_record.get('cmt_committer_timestamp', ''),
+                    fallback=author_corrected,
+                    logger=logger
+                )
 
-                if ":" in tzdata:
-                    tzdata = tzdata.replace(":", "")
+                commit_record['cmt_author_timestamp'] = author_corrected
+                commit_record['cmt_committer_timestamp'] = committer_corrected
 
-                if int(tzdata) not in postgres_valid_timezones:
-                    tzdata = "+0000"
-                else:
-                    raise e
+                logger.warning(
+                    f"Corrected invalid timestamp(s) for commit {commit_record.get('cmt_commit_hash')}"
+                )
 
-                placeholder_date_segments.append(tzdata)
-
-                placeholder_date = " ".join(placeholder_date_segments)
-
-                #Check for improper utc timezone offset
-                #UTC timezone offset should be between -14:00 and +14:00
-
-                # analyzecommit.generate_commit_record() defines the keys on the commit_record dictionary
-                commit_record['cmt_author_timestamp'] = placeholder_date
-                commit_record['cmt_committer_timestamp'] = placeholder_date
-                
-                logger.warning(f"commit with invalid timezone set to UTC: {commit_record['cmt_commit_hash']}")
-
+                # Retry insert with corrected timestamps
                 session.execute(
                     s.insert(Commit),
                     [commit_record],

--- a/collectoss/application/db/timestamp_utils.py
+++ b/collectoss/application/db/timestamp_utils.py
@@ -3,7 +3,8 @@ Timestamp correction utilities for git commit data.
 
 This module provides functions to validate and correct timestamp strings
 before database insertion, specifically handling invalid timezone offsets
-that PostgreSQL cannot process.
+that PostgreSQL cannot process. Resides in the db layer so it can be used
+by db-layer bulk insert logic without crossing into the tasks layer.
 """
 
 import logging

--- a/collectoss/tasks/git/correction.py
+++ b/collectoss/tasks/git/correction.py
@@ -1,0 +1,129 @@
+"""
+Timestamp correction utilities for git commit data.
+
+This module provides functions to validate and correct timestamp strings
+before database insertion, specifically handling invalid timezone offsets
+that PostgreSQL cannot process.
+"""
+
+import logging
+from typing import List, Optional
+
+
+# Valid PostgreSQL timezone offsets in format ±HHMM (e.g., -0500, +0530)
+# Range: -12:00 to +14:00 including all real-world fractional hour offsets
+POSTGRES_VALID_TIMEZONES = {
+    -1200, -1100, -1000, -930, -900, -800, -700,
+    -600, -500, -430, -400, -330, -300, -230, -200, -100, 0,
+    100, 200, 300, 330, 400, 430, 500, 530, 545, 600,
+    630, 700, 800, 845, 900, 930, 1000, 1030, 1100, 1130, 1200,
+    1245, 1300, 1345, 1400
+}
+
+
+def correct_timestamp(
+    timestamp_str: str,
+    fallback: Optional[str] = None,
+    logger: Optional[logging.Logger] = None
+) -> str:
+    """Fix invalid timezone in timestamp string.
+
+    Validates the timezone portion of a timestamp and corrects it if invalid.
+    Handles three cases:
+    1. Valid timezone → return as-is
+    2. Invalid timezone → replace with fallback or UTC
+    3. Unparseable format → return fallback or default
+
+    Args:
+        timestamp_str: Timestamp string in format 'YYYY-MM-DD HH:MM:SS ±HHMM'
+        fallback: Optional fallback timestamp to use if correction needed
+        logger: Optional logger for recording corrections
+
+    Returns:
+        Corrected timestamp string safe for PostgreSQL insertion
+    """
+    if not timestamp_str:
+        return fallback or "1970-01-01 00:00:15 +0000"
+
+    # Split on last space to separate date/time from timezone
+    # Example: '2025-11-03 16:28:43 -0500' → ['2025-11-03 16:28:43', '-0500']
+    parts = timestamp_str.strip().rsplit(' ', 1)
+
+    if len(parts) != 2:
+        # No space found, can't parse
+        if logger:
+            logger.warning(f"Unparseable timestamp format (no space): {timestamp_str}")
+        return fallback or "1970-01-01 00:00:15 +0000"
+
+    date_time, tz_string = parts
+
+    # Validate timezone starts with + or -
+    if not tz_string or tz_string[0] not in ('+', '-'):
+        if logger:
+            logger.warning(f"Unparseable timezone (no sign): {tz_string}")
+        return fallback or "1970-01-01 00:00:15 +0000"
+
+    # Normalize timezone: remove colons (handles both -0500 and -05:00)
+    tz_normalized = tz_string.replace(':', '')
+
+    # Try to parse as integer
+    try:
+        tz_offset = int(tz_normalized)
+    except ValueError:
+        if logger:
+            logger.warning(f"Could not parse timezone as integer: {tz_string}")
+        return fallback or "1970-01-01 00:00:15 +0000"
+
+    # Check if timezone is valid
+    if tz_offset in POSTGRES_VALID_TIMEZONES:
+        # Valid timezone, return original
+        return timestamp_str
+
+    # Invalid timezone detected
+    if fallback:
+        if logger:
+            logger.info(f"Invalid timezone {tz_offset} in '{timestamp_str}', using fallback")
+        return fallback
+
+    # No fallback, default to UTC
+    if logger:
+        logger.warning(f"Invalid timezone {tz_offset} in '{timestamp_str}', defaulting to UTC")
+    return f"{date_time} +0000"
+
+
+def clean_commit_timestamps(records: List[dict], logger: logging.Logger) -> None:
+    """Validate and correct timestamps in commit records in-place.
+
+    Processes a batch of commit records, validating both author and committer
+    timestamps. For invalid committer timestamps, uses the corrected author
+    timestamp as a fallback before defaulting to UTC.
+
+    This prevents PostgreSQL insertion failures due to invalid timezone offsets
+    (e.g., -13068837 which is outside the valid ±14:00 range).
+
+    Args:
+        records: List of commit record dicts with keys:
+                 - 'cmt_author_timestamp'
+                 - 'cmt_committer_timestamp'
+        logger: Logger for recording corrections
+
+    Returns:
+        None (modifies records in-place)
+    """
+    for record in records:
+        author_ts = record.get('cmt_author_timestamp', '')
+        committer_ts = record.get('cmt_committer_timestamp', '')
+
+        # Correct author timestamp first (no fallback, will use UTC if invalid)
+        author_corrected = correct_timestamp(author_ts, fallback=None, logger=logger)
+
+        # Correct committer timestamp, using corrected author as fallback
+        # This minimizes data loss per issue discussion (prefer author time over UTC)
+        committer_corrected = correct_timestamp(
+            committer_ts,
+            fallback=author_corrected,
+            logger=logger
+        )
+
+        record['cmt_author_timestamp'] = author_corrected
+        record['cmt_committer_timestamp'] = committer_corrected

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,7 @@ testpaths = [
     "tests/test_classes",
     "tests/test_application/test_cli/test_csv_utils.py",
     "tests/test_tasks/test_task_utilities/test_util/",
-    "tests/test_tasks/test_git",
+    "tests/test_application/test_db/test_timestamp_utils.py",
     # "tests/test_routes", # runs, but needs a fixture for connecting to the web interface of Augur
     # "tests/test_metrics",
     # "tests/test_tasks",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,7 @@ testpaths = [
     "tests/test_classes",
     "tests/test_application/test_cli/test_csv_utils.py",
     "tests/test_tasks/test_task_utilities/test_util/",
+    "tests/test_tasks/test_git",
     # "tests/test_routes", # runs, but needs a fixture for connecting to the web interface of Augur
     # "tests/test_metrics",
     # "tests/test_tasks",

--- a/tests/test_application/test_db/test_timestamp_utils.py
+++ b/tests/test_application/test_db/test_timestamp_utils.py
@@ -1,13 +1,13 @@
 """
 Unit tests for git commit timestamp correction functions.
 
-Tests the correction.py module which validates and corrects invalid
+Tests the timestamp_utils module which validates and corrects invalid
 timezone offsets in git commit timestamps before PostgreSQL insertion.
 """
 
 import pytest
 import logging
-from augur.tasks.git.correction import (
+from augur.application.db.timestamp_utils import (
     correct_timestamp,
     clean_commit_timestamps,
     POSTGRES_VALID_TIMEZONES
@@ -65,6 +65,17 @@ class TestCorrectTimestamp:
         unparseable = "not a timestamp"
         fallback = "2025-11-03 16:28:43 -0500"
         result = correct_timestamp(unparseable, fallback=fallback, logger=test_logger)
+        assert result == fallback
+
+    def test_none_returns_default(self, test_logger):
+        """None timestamp (e.g. from record.get() with no default) should return default epoch."""
+        result = correct_timestamp(None, logger=test_logger)
+        assert result == "1970-01-01 00:00:15 +0000"
+
+    def test_none_with_fallback_returns_fallback(self, test_logger):
+        """None timestamp with fallback should return fallback."""
+        fallback = "2025-11-03 16:28:43 -0500"
+        result = correct_timestamp(None, fallback=fallback, logger=test_logger)
         assert result == fallback
 
 

--- a/tests/test_application/test_db/test_timestamp_utils.py
+++ b/tests/test_application/test_db/test_timestamp_utils.py
@@ -7,7 +7,7 @@ timezone offsets in git commit timestamps before PostgreSQL insertion.
 
 import pytest
 import logging
-from augur.application.db.timestamp_utils import (
+from collectoss.application.db.timestamp_utils import (
     correct_timestamp,
     clean_commit_timestamps,
     POSTGRES_VALID_TIMEZONES

--- a/tests/test_tasks/test_git/test_correction.py
+++ b/tests/test_tasks/test_git/test_correction.py
@@ -1,0 +1,158 @@
+"""
+Unit tests for git commit timestamp correction functions.
+
+Tests the correction.py module which validates and corrects invalid
+timezone offsets in git commit timestamps before PostgreSQL insertion.
+"""
+
+import pytest
+import logging
+from augur.tasks.git.correction import (
+    correct_timestamp,
+    clean_commit_timestamps,
+    POSTGRES_VALID_TIMEZONES
+)
+
+
+@pytest.fixture
+def logger():
+    """Provide a basic logger for tests."""
+    return logging.getLogger("test_correction")
+
+
+class TestCorrectTimestamp:
+    """Tests for the correct_timestamp function."""
+
+    def test_valid_timestamp_unchanged(self, logger):
+        """Valid timestamp should pass through unchanged."""
+        valid_ts = "2025-11-03 16:28:43 -0500"
+        result = correct_timestamp(valid_ts, logger=logger)
+        assert result == valid_ts
+
+    def test_valid_utc_timestamp(self, logger):
+        """UTC timestamp (offset 0) should pass through unchanged."""
+        utc_ts = "2025-11-03 16:28:43 +0000"
+        result = correct_timestamp(utc_ts, logger=logger)
+        assert result == utc_ts
+
+    def test_invalid_timezone_uses_fallback(self, logger):
+        """Invalid timezone should use fallback timestamp."""
+        invalid_ts = "2106-02-07 06:28:23 -13068837"
+        fallback_ts = "2025-11-03 16:28:43 -0500"
+        result = correct_timestamp(invalid_ts, fallback=fallback_ts, logger=logger)
+        assert result == fallback_ts
+
+    def test_invalid_timezone_uses_utc_if_no_fallback(self, logger):
+        """Invalid timezone without fallback should default to UTC."""
+        invalid_ts = "2106-02-07 06:28:23 -13068837"
+        result = correct_timestamp(invalid_ts, fallback=None, logger=logger)
+        # Should replace timezone with +0000, keep date/time
+        assert result == "2106-02-07 06:28:23 +0000"
+
+    def test_empty_string_returns_default(self, logger):
+        """Empty timestamp string should return default epoch."""
+        result = correct_timestamp("", logger=logger)
+        assert result == "1970-01-01 00:00:15 +0000"
+
+    def test_unparseable_format_returns_default(self, logger):
+        """Unparseable timestamp format should return default."""
+        unparseable = "not a timestamp"
+        result = correct_timestamp(unparseable, logger=logger)
+        assert result == "1970-01-01 00:00:15 +0000"
+
+    def test_unparseable_with_fallback_returns_fallback(self, logger):
+        """Unparseable timestamp with fallback should return fallback."""
+        unparseable = "not a timestamp"
+        fallback = "2025-11-03 16:28:43 -0500"
+        result = correct_timestamp(unparseable, fallback=fallback, logger=logger)
+        assert result == fallback
+
+
+class TestCleanCommitTimestamps:
+    """Tests for the clean_commit_timestamps function."""
+
+    def test_issue_3472_exact_case(self, logger):
+        """Reproduce the exact bug from issue #3472.
+
+        Author timestamp has valid timezone (-0500).
+        Committer timestamp has invalid timezone (-13068837).
+        Should use author timestamp as fallback for committer.
+        """
+        records = [
+            {
+                'cmt_commit_hash': '5de262a839',
+                'cmt_author_timestamp': '2025-11-03 16:28:43 -0500',
+                'cmt_committer_timestamp': '2106-02-07 06:28:23 -13068837'
+            }
+        ]
+
+        clean_commit_timestamps(records, logger)
+
+        # Author should be unchanged (valid)
+        assert records[0]['cmt_author_timestamp'] == '2025-11-03 16:28:43 -0500'
+
+        # Committer should use author as fallback (invalid → fallback)
+        assert records[0]['cmt_committer_timestamp'] == '2025-11-03 16:28:43 -0500'
+
+    def test_clean_commit_timestamps_batch(self, logger):
+        """Test batch processing of multiple commits."""
+        records = [
+            {
+                'cmt_author_timestamp': '2025-11-03 16:28:43 -0500',  # Valid
+                'cmt_committer_timestamp': '2025-11-03 16:28:43 -0500'  # Valid
+            },
+            {
+                'cmt_author_timestamp': '2025-11-04 10:00:00 +0000',  # Valid
+                'cmt_committer_timestamp': '2106-02-07 06:28:23 -99999'  # Invalid
+            },
+            {
+                'cmt_author_timestamp': '2025-11-05 12:00:00 -12345',  # Invalid
+                'cmt_committer_timestamp': '2025-11-05 13:00:00 +0530'  # Valid
+            }
+        ]
+
+        clean_commit_timestamps(records, logger)
+
+        # Record 1: Both valid, unchanged
+        assert records[0]['cmt_author_timestamp'] == '2025-11-03 16:28:43 -0500'
+        assert records[0]['cmt_committer_timestamp'] == '2025-11-03 16:28:43 -0500'
+
+        # Record 2: Author valid, committer invalid → use author as fallback
+        assert records[1]['cmt_author_timestamp'] == '2025-11-04 10:00:00 +0000'
+        assert records[1]['cmt_committer_timestamp'] == '2025-11-04 10:00:00 +0000'
+
+        # Record 3: Author invalid → UTC, committer valid → unchanged
+        assert records[2]['cmt_author_timestamp'] == '2025-11-05 12:00:00 +0000'
+        assert records[2]['cmt_committer_timestamp'] == '2025-11-05 13:00:00 +0530'
+
+    def test_both_timestamps_invalid(self, logger):
+        """When both timestamps invalid, both should default to UTC."""
+        records = [
+            {
+                'cmt_author_timestamp': '2025-11-03 16:28:43 -99999',
+                'cmt_committer_timestamp': '2106-02-07 06:28:23 -88888'
+            }
+        ]
+
+        clean_commit_timestamps(records, logger)
+
+        # Author invalid → UTC (no fallback)
+        assert records[0]['cmt_author_timestamp'] == '2025-11-03 16:28:43 +0000'
+
+        # Committer invalid → fallback to corrected author (which is UTC)
+        assert records[0]['cmt_committer_timestamp'] == '2025-11-03 16:28:43 +0000'
+
+
+class TestPostgresValidTimezones:
+    """Verify the POSTGRES_VALID_TIMEZONES set is correct."""
+
+    def test_valid_timezones_range(self):
+        """Valid timezones should be in range -12:00 to +14:00."""
+        for tz in POSTGRES_VALID_TIMEZONES:
+            assert -1200 <= tz <= 1400
+
+    def test_common_timezones_present(self):
+        """Common timezone offsets should be in the set."""
+        common = [0, -500, -400, -800, 100, 530, 800]  # UTC, EST, EDT, PST, CET, IST, CST
+        for tz in common:
+            assert tz in POSTGRES_VALID_TIMEZONES

--- a/tests/test_tasks/test_git/test_correction.py
+++ b/tests/test_tasks/test_git/test_correction.py
@@ -15,7 +15,7 @@ from augur.tasks.git.correction import (
 
 
 @pytest.fixture
-def logger():
+def test_logger():
     """Provide a basic logger for tests."""
     return logging.getLogger("test_correction")
 
@@ -23,55 +23,55 @@ def logger():
 class TestCorrectTimestamp:
     """Tests for the correct_timestamp function."""
 
-    def test_valid_timestamp_unchanged(self, logger):
+    def test_valid_timestamp_unchanged(self, test_logger):
         """Valid timestamp should pass through unchanged."""
         valid_ts = "2025-11-03 16:28:43 -0500"
-        result = correct_timestamp(valid_ts, logger=logger)
+        result = correct_timestamp(valid_ts, logger=test_logger)
         assert result == valid_ts
 
-    def test_valid_utc_timestamp(self, logger):
+    def test_valid_utc_timestamp(self, test_logger):
         """UTC timestamp (offset 0) should pass through unchanged."""
         utc_ts = "2025-11-03 16:28:43 +0000"
-        result = correct_timestamp(utc_ts, logger=logger)
+        result = correct_timestamp(utc_ts, logger=test_logger)
         assert result == utc_ts
 
-    def test_invalid_timezone_uses_fallback(self, logger):
+    def test_invalid_timezone_uses_fallback(self, test_logger):
         """Invalid timezone should use fallback timestamp."""
         invalid_ts = "2106-02-07 06:28:23 -13068837"
         fallback_ts = "2025-11-03 16:28:43 -0500"
-        result = correct_timestamp(invalid_ts, fallback=fallback_ts, logger=logger)
+        result = correct_timestamp(invalid_ts, fallback=fallback_ts, logger=test_logger)
         assert result == fallback_ts
 
-    def test_invalid_timezone_uses_utc_if_no_fallback(self, logger):
+    def test_invalid_timezone_uses_utc_if_no_fallback(self, test_logger):
         """Invalid timezone without fallback should default to UTC."""
         invalid_ts = "2106-02-07 06:28:23 -13068837"
-        result = correct_timestamp(invalid_ts, fallback=None, logger=logger)
+        result = correct_timestamp(invalid_ts, fallback=None, logger=test_logger)
         # Should replace timezone with +0000, keep date/time
         assert result == "2106-02-07 06:28:23 +0000"
 
-    def test_empty_string_returns_default(self, logger):
+    def test_empty_string_returns_default(self, test_logger):
         """Empty timestamp string should return default epoch."""
-        result = correct_timestamp("", logger=logger)
+        result = correct_timestamp("", logger=test_logger)
         assert result == "1970-01-01 00:00:15 +0000"
 
-    def test_unparseable_format_returns_default(self, logger):
+    def test_unparseable_format_returns_default(self, test_logger):
         """Unparseable timestamp format should return default."""
         unparseable = "not a timestamp"
-        result = correct_timestamp(unparseable, logger=logger)
+        result = correct_timestamp(unparseable, logger=test_logger)
         assert result == "1970-01-01 00:00:15 +0000"
 
-    def test_unparseable_with_fallback_returns_fallback(self, logger):
+    def test_unparseable_with_fallback_returns_fallback(self, test_logger):
         """Unparseable timestamp with fallback should return fallback."""
         unparseable = "not a timestamp"
         fallback = "2025-11-03 16:28:43 -0500"
-        result = correct_timestamp(unparseable, fallback=fallback, logger=logger)
+        result = correct_timestamp(unparseable, fallback=fallback, logger=test_logger)
         assert result == fallback
 
 
 class TestCleanCommitTimestamps:
     """Tests for the clean_commit_timestamps function."""
 
-    def test_issue_3472_exact_case(self, logger):
+    def test_issue_3472_exact_case(self, test_logger):
         """Reproduce the exact bug from issue #3472.
 
         Author timestamp has valid timezone (-0500).
@@ -86,7 +86,7 @@ class TestCleanCommitTimestamps:
             }
         ]
 
-        clean_commit_timestamps(records, logger)
+        clean_commit_timestamps(records, test_logger)
 
         # Author should be unchanged (valid)
         assert records[0]['cmt_author_timestamp'] == '2025-11-03 16:28:43 -0500'
@@ -94,7 +94,7 @@ class TestCleanCommitTimestamps:
         # Committer should use author as fallback (invalid → fallback)
         assert records[0]['cmt_committer_timestamp'] == '2025-11-03 16:28:43 -0500'
 
-    def test_clean_commit_timestamps_batch(self, logger):
+    def test_clean_commit_timestamps_batch(self, test_logger):
         """Test batch processing of multiple commits."""
         records = [
             {
@@ -111,7 +111,7 @@ class TestCleanCommitTimestamps:
             }
         ]
 
-        clean_commit_timestamps(records, logger)
+        clean_commit_timestamps(records, test_logger)
 
         # Record 1: Both valid, unchanged
         assert records[0]['cmt_author_timestamp'] == '2025-11-03 16:28:43 -0500'
@@ -125,7 +125,7 @@ class TestCleanCommitTimestamps:
         assert records[2]['cmt_author_timestamp'] == '2025-11-05 12:00:00 +0000'
         assert records[2]['cmt_committer_timestamp'] == '2025-11-05 13:00:00 +0530'
 
-    def test_both_timestamps_invalid(self, logger):
+    def test_both_timestamps_invalid(self, test_logger):
         """When both timestamps invalid, both should default to UTC."""
         records = [
             {
@@ -134,7 +134,7 @@ class TestCleanCommitTimestamps:
             }
         ]
 
-        clean_commit_timestamps(records, logger)
+        clean_commit_timestamps(records, test_logger)
 
         # Author invalid → UTC (no fallback)
         assert records[0]['cmt_author_timestamp'] == '2025-11-03 16:28:43 +0000'


### PR DESCRIPTION
**Description**

Fixes #157. originally filed by @shlokgilda  in https://github.com/augurlabs/augur/pull/3518

**The Bug:**
`facade_bulk_insert_commits()` only validated `cmt_author_timestamp` when handling DB insertion failures. If the author timestamp was valid but the committer timestamp had an invalid timezone (e.g., `-13068837` from git corruption), the insert would fail permanently.

**The Fix:**
- Created `augur/tasks/git/correction.py` with timezone validation functions (simple string operations)
- Modified `lib.py` to validate **both** author and committer timestamps when the binary search isolates a problematic commit
- Uses author timestamp as fallback for invalid committer timestamp to minimize data loss
- Only validates on insertion failure (keeps the existing performance optimization intact)

**Changes:**
1. **NEW:** `augur/tasks/git/correction.py` - Timestamp validation utilities
2. **MODIFIED:** `augur/application/db/lib.py` - Now validates both timestamps on failure
3. **NEW:** `tests/test_tasks/test_git/test_correction.py` - 12 unit tests (all passing)

**Notes for Reviewers**
- The fix maintains the existing binary search optimization - we only validate timestamps when PostgreSQL rejects an insert, not proactively
- `POSTGRES_VALID_TIMEZONES` includes all real-world timezone offsets (-12:00 to +14:00). Some of the timezone offsets were missing. Reference: https://docs.oracle.com/cd/E19563-01/819-4437/anovd/index.html
- Fallback chain: invalid committer → use author timestamp → UTC (minimizes data loss per issue discussion)

**Signed commits**
- [x] Yes, I signed my commits.

---

**AI Disclosure:** I used Claude Code to assist with writing docstrings, code review, writing test cases, and drafting this PR description. All test cases were manually verified and are passing locally.