### PR TITLE
fix(tasks): remove debug print statements causing log spam

### DIFF
--- a/collectoss/tasks/git/dependency_libyear_tasks/libyear_util/pypi_libyear_util.py
+++ b/collectoss/tasks/git/dependency_libyear_tasks/libyear_util/pypi_libyear_util.py
@@ -117,6 +117,5 @@ def get_libyear(current_version, current_release_date, latest_version, latest_re
     latest_release_date = dateutil.parser.parse(latest_release_date)    
 
     libdays = (latest_release_date - current_release_date).days
-    print(libdays)
     libyear = libdays/365
     return libyear

--- a/collectoss/tasks/git/dependency_libyear_tasks/libyear_util/util.py
+++ b/collectoss/tasks/git/dependency_libyear_tasks/libyear_util/util.py
@@ -95,7 +95,6 @@ def get_libyear(current_version, current_release_date, latest_version, latest_re
     latest_release_date = dateutil.parser.parse(latest_release_date)    
 
     libdays = (latest_release_date - current_release_date).days
-    print(libdays)
     libyear = libdays/365
     return libyear
 


### PR DESCRIPTION
## What problem does this solve?
Removes two debug `print(libdays)` statements that were outputting bare numbers to stdout during dependency libyear analysis, causing log spam reported in issue #289.

## What changed and why?
Removed `print(libdays)` from two locations:
- `collectoss/tasks/git/dependency_libyear_tasks/libyear_util/util.py`
- `collectoss/tasks/git/dependency_libyear_tasks/libyear_util/pypi_libyear_util.py`

These debug prints were left in the codebase and caused the log noise: `0`, `497`, `932`, etc. appearing in task logs.

## How was this tested?
- Searched codebase for similar patterns — no other occurrences found
- Verified the function still correctly calculates and returns libyear after the change

## Checklist
- [x] Read CONTRIBUTING.md  
- [x] Changes match project coding style
- [x] No test changes needed (debug print removal only)
- [x] CI tools: pylint check will run

---
*This contribution was created with AI assistance, with human review and approval at each step.*
