### PR TITLE
remove rabbitmq default user tags

### DIFF
--- a/docker/rabbitmq/collectoss.conf
+++ b/docker/rabbitmq/collectoss.conf
@@ -5,7 +5,3 @@ default_permissions.read = .*
 default_permissions.write = .*
 
 default_user_tags.administrator = true
-default_user_tags.augur = true
-default_user_tags.augurTag = true
-default_user_tags.collectoss = true
-default_user_tags.collectossTag = true


### PR DESCRIPTION
**Description**
According to my own poking through the code (around when #2 was being worked on), as well as asking claude 4.6 opus high, These user tags seem to not be used anywhere in the code and have no special meaning within rabbitmq.

This PR removes them and fixes #327 

**Notes for Reviewers**

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/collectoss/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->