### PR TITLE
update bandit actions config to a more current version

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -13,12 +13,12 @@
 name: Bandit
 on:
   push:
-    branches: [ "main", "release" ]
+    branches: ["main", "release"]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: ["main"]
   schedule:
-    - cron: '24 2 * * 2'
+    - cron: "24 2 * * 2"
 
 jobs:
   bandit:
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Bandit Scan
-        uses: shundor/python-bandit-scan@ab1d87dfccc5a0ffab88be3aaac6ffe35c10d6cd
+        uses: reactive-firewall/python-bandit-scan@11a72c7c18aab77758bf6f5d9456f1018ec107b0
         with: # optional arguments
           # exit with 0, even with results found
           exit_zero: true # optional, default is DEFAULT
@@ -43,9 +43,9 @@ jobs:
           # Report only issues of a given confidence level or higher. Can be LOW, MEDIUM or HIGH. Default is UNDEFINED (everything)
           # confidence: # optional, default is UNDEFINED
           # comma-separated list of paths (glob patterns supported) to exclude from scan (note that these are in addition to the excluded paths provided in the config file) (default: .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg)
-          excluded_paths: tests
+          # excluded_paths:
           # comma-separated list of test IDs to skip
           # skips: # optional, default is DEFAULT
           # path to a .bandit file that supplies command line arguments
           # ini_path: # optional, default is DEFAULT
-
+          config_path: pyproject.toml


### PR DESCRIPTION
**Description**
Despite multiple previous attempts (i.e. #266 ), Bandit is still flagging scan results in unit test files.

This seems to be caused by the outdated nature of the upstream action. While the action had a way to exclude "paths", I suspect this wasnt getting passed in correctly (or was being interpreted as a file path, not a directory). This, combined with a lack of a config item that mapped to `-c` for specifiying a config file (i.e. our `pyproject.toml`), meant that bandit likely wasn't even seeing the preference we had set to ignore the `tests` directory.

This PR updates our bandit job to be based on the changes proposed in https://github.com/shundor/python-bandit-scan/pull/6, which bring in this `-c` configuration value, as well as bump some other components to newer versions.

This PR fixes #239 

**Notes for Reviewers**
As a CI job, testing will probably need to be done mainly after-merge to see if this has an impact. my plan is to (once again) clear out all the false positive results from unit test files in the github code scanning tab  and then wait for the next tuesday (when this action is scheduled to rerun)

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/collectoss/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->