### PR TITLE
nullify migration that should never have been a migration

### DIFF
--- a/collectoss/application/schema/alembic/versions/34_add_contrib_to_config.py
+++ b/collectoss/application/schema/alembic/versions/34_add_contrib_to_config.py
@@ -20,38 +20,8 @@ depends_on = None
 logger = logging.getLogger(__name__)
 
 def upgrade():
-
-    with DatabaseSession(logger) as session:
-        config = SystemConfig(logger,session)
-        config_dict = config.load_config()
-
-        #Update the missing fields of the facade section in the config
-        section = config_dict.get("Facade")
-
-        #Just copy the default if section doesn't exist.
-        if section:
-            if 'facade_contributor_full_recollect' not in section.keys():
-                section['facade_contributor_full_recollect'] = 0
-            
-        else:
-            section = config.default_config["Facade"]
-        
-        config.add_section_from_json("Facade", section)
+    pass
 
 
 def downgrade():
-
-    conn = op.get_bind()
-
-    conn.execute(text(f"""
-        DELETE FROM augur_operations.config
-        WHERE section_name='Facade' AND (setting_name='facade_contributor_full_recollect');
-    """))
-
-    try:
-        conn.execute(text(f"""
-            DELETE FROM augur_operations.config
-            WHERE section_name='Facade' AND (setting_name='facade_contributor_full_recollect');
-        """))
-    except:
-        pass
+    pass


### PR DESCRIPTION
**Description**
This migration was created to insert a new config value into the database. 

This was identified as a problem/incorrect use of alembic scripts, arguably before it was even committed. It shouldnt have existed in the first place.

The correct solution to this problem was the config management hierarchy system that was introduced shortly after this rolled out.

This oversight is now causing problems.

Because of the database schema rename effort (#324) the import of the config class in this migration creates a catch-22 that causes CI failures with that PR.

when we initialize a new database, we do so by restoring a static augur database and then replaying every migration since then (another problem tracked in #132). When this restore gets to the migration in this PR, it imports the config class, which in the context of #324 has already been updated to use the new schema names. However we havent yet gotten to the migration that renames the schemas, so this will always fail.

This highlights the importance of:
1. not using alembic for changing the data/contents of a database (unless you are doing so to migrate data as part of a structural move)
2. ensuring that the schemas/models being used in alembic scripts are being COPIED in, not referenced, so that they remain fixed as they are at that specific point in time, rather than breaking as the importable versions continually evolve.

This PR is largely a hotfix to temporarily break this deadlock on a time sensitive/important issue (the schema rename) to avoid further going down the rabbithole. This removes the time pressure from the development and testing of the proper solution (not initializing databases using the upgrade/downgrade system).

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
3. Build and test your changes before submitting a PR. 
4. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/collectoss/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->