### PR TITLE
docs: re-introduce data sources section to scope.rst

### DIFF
--- a/docs/source/about/scope.rst
+++ b/docs/source/about/scope.rst
@@ -8,3 +8,14 @@ This scope is intentionally narrower than that of the CHAOSS project as a whole 
 Usecases and discussion of perspectives outside this defined scope are still welcome in the CHAOSS community, but may not be a good fit for direct contributions to CollectOSS.
 These usecases may work best as a complementary add-on project, new working group, or third-party addon to collectoss that depends on or extends CollectOSS functionality.
 Future expansions of CollectOSS's scope may also bring in these community addons into the main codebase if new resources become available to sustain such expansion.
+
+Data Sources
+------------
+
+CollectOSS collects data from a variety of sources:
+
+1. Raw Git commit logs (commits, contributors)
+2. GitHub's API (issues, pull requests, contributors, releases, repository metadata)
+3. The Linux Foundation's `Core Infrastructure Initiative <https://www.coreinfrastructure.org/>`_ API (repository metadata)
+4. `Succinct Code Counter <https://github.com/boyter/scc>`_, a blazingly fast Sloc, Cloc, and Code tool that also performs COCOMO calculations
+5. `OpenSSF Scorecard <https://securityscorecards.dev/>`_ analysis (security health metrics for open source projects)

--- a/docs/source/about/scope.rst
+++ b/docs/source/about/scope.rst
@@ -8,14 +8,3 @@ This scope is intentionally narrower than that of the CHAOSS project as a whole 
 Usecases and discussion of perspectives outside this defined scope are still welcome in the CHAOSS community, but may not be a good fit for direct contributions to CollectOSS.
 These usecases may work best as a complementary add-on project, new working group, or third-party addon to collectoss that depends on or extends CollectOSS functionality.
 Future expansions of CollectOSS's scope may also bring in these community addons into the main codebase if new resources become available to sustain such expansion.
-
-Data Sources
-------------
-
-CollectOSS collects data from a variety of sources:
-
-1. Raw Git commit logs (commits, contributors)
-2. GitHub's API (issues, pull requests, contributors, releases, repository metadata)
-3. The Linux Foundation's `Core Infrastructure Initiative <https://www.coreinfrastructure.org/>`_ API (repository metadata)
-4. `Succinct Code Counter <https://github.com/boyter/scc>`_, a blazingly fast Sloc, Cloc, and Code tool that also performs COCOMO calculations
-5. `OpenSSF Scorecard <https://securityscorecards.dev/>`_ analysis (security health metrics for open source projects)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -44,6 +44,17 @@ How CollectOSS works
 3. It organizes this data into a standard format called a data model.
 4. Then it calculates metrics that tell you about the project’s health.
 
+Where CollectOSS gets its data
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+CollectOSS collects data from a variety of sources:
+
+1. Raw Git commit logs (commits, contributors)
+2. GitHub’s API (issues, pull requests, contributors, releases, repository metadata)
+3. The Linux Foundation’s `Core Infrastructure Initiative <https://www.coreinfrastructure.org/>`_ API (repository metadata)
+4. `Succinct Code Counter <https://github.com/boyter/scc>`_, a blazingly fast Sloc, Cloc, and Code tool that also performs COCOMO calculations
+5. `OpenSSF Scorecard <https://securityscorecards.dev/>`_ analysis (security health metrics for open source projects)
+
 Example of a metric: Burstiness
 -------------------------------
 - Burstiness is one of CollectOSS’s metrics.


### PR DESCRIPTION
Re-adds the data sources list that was removed from the README in PR #2 and adds it to the readthedocs documentation as intended. Also adds a 5th entry for OpenSSF Scorecard analysis as suggested.

Fixes #335

**Description**
- Please include a summary of the change.

This PR fixes #

**Notes for Reviewers**

**Signed commits**
- [x] Yes, I signed my commits.
