### PR TITLE
ci: bump python-bandit-scan to use codeql-action/upload-sarif v4

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Bandit Scan
-        uses: reactive-firewall/python-bandit-scan@11a72c7c18aab77758bf6f5d9456f1018ec107b0
+        uses: reactive-firewall/python-bandit-scan@88ecea175f67a97e97ebe4a1a2761135b8e10aa0
         with: # optional arguments
           # exit with 0, even with results found
           exit_zero: true # optional, default is DEFAULT


### PR DESCRIPTION
The previous pinned commit (11a72c7c) used github/codeql-action/upload-sarif@v3 which is being deprecated in December 2025. Updated to the latest commit (88ecea17) which uses upload-sarif@v4.

Fixes #349

**Description**
- Please include a summary of the change.

This PR fixes #

**Notes for Reviewers**

**Signed commits**
- [x] Yes, I signed my commits.