### PR TITLE
fix: replace rounded-circle with rounded on logo in admin pages

### DIFF
--- a/collectoss/templates/admin-dashboard.j2
+++ b/collectoss/templates/admin-dashboard.j2
@@ -45,7 +45,7 @@
                 <hr>
                 <div class="dropdown">
                     <a href="{{ url_for('root') }}" class="d-flex align-items-center text-white text-decoration-none">
-                        <img src="{{ url_for('logo') }}" alt="CollectOSS logo" height="32" class="rounded-circle me-2">
+                        <img src="{{ url_for('logo') }}" alt="CollectOSS logo" height="32" class="rounded me-2">
                     </a>
                     {# Reserved for future use
                     <ul class="dropdown-menu dropdown-menu-dark text-small shadow" aria-labelledby="dropdownUser1">

--- a/collectoss/templates/settings.j2
+++ b/collectoss/templates/settings.j2
@@ -40,7 +40,7 @@
                     class="d-flex flex-md-column text-truncate flex-row flex-grow-1 align-items-center align-items-md-start px-3 py-2 text-white">
                     <a href="{{ url_for('root') }}"
                         class="d-flex align-items-around mw-100 text-white text-decoration-none">
-                        <img src="{{ url_for('logo') }}" alt="CollectOSS logo" height="40" class="rounded-circle me-2">
+                        <img src="{{ url_for('logo') }}" alt="CollectOSS logo" height="40" class="rounded me-2">
                     </a>
                     <ul class="nav nav-pills flex-md-column flex-row flex-nowrap flex-shrink-1 flex-md-grow-0 flex-grow-1 mb-md-auto mb-0 justify-content-center align-items-center align-items-md-start"
                         id="menu">


### PR DESCRIPTION

<img width="806" height="321" alt="Screenshot 2026-06-08 193236" src="https://github.com/user-attachments/assets/620e5f0d-71aa-477a-901c-88c4f296e714" />
The CollectOSS logo was being cropped on the admin dashboard and user 
settings pages due to Bootstrap's `rounded-circle` class, which applies a 
50% border-radius circular mask to the rectangular logo image.

Replaced `rounded-circle` with `rounded` in both:
- `collectoss/templates/admin-dashboard.j2`
- `collectoss/templates/settings.j2`

This preserves a subtle rounded corner without cropping the logo.

This PR fixes #302

**Notes for Reviewers**
Two one-word changes in template files. No logic changes.

**Signed commits**
- [x] Yes, I signed my commits.