### PR TITLE
Fix: Eliminate redundant full table scans in messages and events collection

### DIFF
--- a/collectoss/tasks/github/events.py
+++ b/collectoss/tasks/github/events.py
@@ -117,6 +117,10 @@ class BulkGithubEventCollection(GithubEventCollection):
         self.repo_identifier = f"{owner}/{repo}"
 
         event_batch_size = get_batch_size("event")
+        
+        # Build mappings once before processing any events
+        issue_url_to_id_map = self._get_map_from_issue_url_to_id(repo_id)
+        pr_url_to_id_map = self._get_map_from_pr_url_to_id(repo_id)
 
         events = []
         for event in self._collect_events(repo_git, key_auth, since):
@@ -124,11 +128,11 @@ class BulkGithubEventCollection(GithubEventCollection):
 
             # making this a decent size since process_events retrieves all the issues and prs each time
             if len(events) >= event_batch_size:
-                self._process_events(events, repo_id)
+                self._process_events(events, repo_id, issue_url_to_id_map, pr_url_to_id_map)
                 events.clear()
     
         if events:
-            self._process_events(events, repo_id)
+            self._process_events(events, repo_id, issue_url_to_id_map, pr_url_to_id_map)
         
     def _collect_events(self, repo_git: str, key_auth, since):
 
@@ -146,7 +150,7 @@ class BulkGithubEventCollection(GithubEventCollection):
             if since and datetime.fromisoformat(event["created_at"].replace("Z", "+00:00")).replace(tzinfo=timezone.utc) < since:
                 return  
 
-    def _process_events(self, events, repo_id):
+    def _process_events(self, events, repo_id, issue_url_to_id_map, pr_url_to_id_map):
 
         issue_events = []
         pr_events = []
@@ -164,18 +168,15 @@ class BulkGithubEventCollection(GithubEventCollection):
         if not_mappable_events:
             self._logger.warning(f"{self.repo_identifier} - {self.task_name}: Unable to map these github events to an issue or pr: {not_mappable_events}")
 
-        self._process_issue_events(issue_events, repo_id)
-        self._process_pr_events(pr_events, repo_id)
+        self._process_issue_events(issue_events, repo_id, issue_url_to_id_map)
+        self._process_pr_events(pr_events, repo_id, pr_url_to_id_map)
 
         update_issue_closed_cntrbs_by_repo_id(repo_id)
 
-    def _process_issue_events(self, issue_events, repo_id):
+    def _process_issue_events(self, issue_events, repo_id, issue_url_to_id_map):
         
         issue_event_dicts = []
         contributors = []
-
-
-        issue_url_to_id_map = self._get_map_from_issue_url_to_id(repo_id)
 
         for event in issue_events:
 
@@ -203,12 +204,10 @@ class BulkGithubEventCollection(GithubEventCollection):
 
         self._insert_issue_events(issue_event_dicts)
 
-    def _process_pr_events(self, pr_events, repo_id):
+    def _process_pr_events(self, pr_events, repo_id, pr_url_to_id_map):
                 
         pr_event_dicts = []
         contributors = []
-
-        pr_url_to_id_map = self._get_map_from_pr_url_to_id(repo_id)
 
         for event in pr_events:
 

--- a/collectoss/tasks/github/messages.py
+++ b/collectoss/tasks/github/messages.py
@@ -39,17 +39,30 @@ def collect_github_messages(repo_git: str, full_collection: bool) -> None:
             core_data_last_collected = (get_core_data_last_collected(repo_id) - timedelta(days=2)).replace(tzinfo=timezone.utc)
 
         
+        # Build mappings once before processing any messages
+        # create mapping from issue url to issue id of current issues
+        issue_url_to_id_map = {}
+        issues = db_session.session.query(Issue).filter(Issue.repo_id == repo_id).all()
+        for issue in issues:
+            issue_url_to_id_map[issue.issue_url] = issue.issue_id
+
+        # create mapping from pr url to pr id of current pull requests
+        pr_issue_url_to_id_map = {}
+        prs = db_session.session.query(PullRequest).filter(PullRequest.repo_id == repo_id).all()
+        for pr in prs:
+            pr_issue_url_to_id_map[pr.pr_issue_url] = pr.pull_request_id
+
         if is_repo_small(repo_id):
             message_data = fast_retrieve_all_pr_and_issue_messages(repo_git, logger, manifest.key_auth, task_name, core_data_last_collected)
             
             if message_data:
-                process_messages(message_data, task_name, repo_id, logger, db_session)
+                process_messages(message_data, task_name, repo_id, logger, db_session, issue_url_to_id_map, pr_issue_url_to_id_map)
 
             else:
                 logger.info(f"{owner}/{repo} has no messages")
 
         else:
-            process_large_issue_and_pr_message_collection(repo_id, repo_git, logger, manifest.key_auth, task_name, db_session, core_data_last_collected)
+            process_large_issue_and_pr_message_collection(repo_id, repo_git, logger, manifest.key_auth, task_name, db_session, core_data_last_collected, issue_url_to_id_map, pr_issue_url_to_id_map)
 
 
 def is_repo_small(repo_id):
@@ -82,7 +95,7 @@ def fast_retrieve_all_pr_and_issue_messages(repo_git: str, logger, key_auth, tas
     return list(github_data_access.paginate_resource(url))
 
 
-def process_large_issue_and_pr_message_collection(repo_id, repo_git: str, logger, key_auth, task_name, db_session, since) -> None:
+def process_large_issue_and_pr_message_collection(repo_id, repo_git: str, logger, key_auth, task_name, db_session, since, issue_url_to_id_map, pr_issue_url_to_id_map) -> None:
 
     message_batch_size = get_batch_size("message")
 
@@ -129,16 +142,16 @@ def process_large_issue_and_pr_message_collection(repo_id, repo_git: str, logger
             skipped_urls += 1
 
         if len(all_data) >= message_batch_size:
-            process_messages(all_data, task_name, repo_id, logger, db_session)
+            process_messages(all_data, task_name, repo_id, logger, db_session, issue_url_to_id_map, pr_issue_url_to_id_map)
             all_data.clear()
 
     if len(all_data) > 0:
-        process_messages(all_data, task_name, repo_id, logger, db_session)
+        process_messages(all_data, task_name, repo_id, logger, db_session, issue_url_to_id_map, pr_issue_url_to_id_map)
 
     logger.info(f"{task_name}: Finished. Skipped {skipped_urls} comment URLs due to 404.")
         
 
-def process_messages(messages, task_name, repo_id, logger, db_session):
+def process_messages(messages, task_name, repo_id, logger, db_session, issue_url_to_id_map, pr_issue_url_to_id_map):
 
     tool_version = "2.0"
     data_source = "Github API"
@@ -153,18 +166,6 @@ def process_messages(messages, task_name, repo_id, logger, db_session):
 
     if len(messages) == 0:
         logger.info(f"{task_name}: No messages to process")
-
-    # create mapping from issue url to issue id of current issues
-    issue_url_to_id_map = {}
-    issues = db_session.session.query(Issue).filter(Issue.repo_id == repo_id).all()
-    for issue in issues:
-        issue_url_to_id_map[issue.issue_url] = issue.issue_id
-
-    # create mapping from pr url to pr id of current pull requests
-    pr_issue_url_to_id_map = {}
-    prs = db_session.session.query(PullRequest).filter(PullRequest.repo_id == repo_id).all()
-    for pr in prs:
-        pr_issue_url_to_id_map[pr.pr_issue_url] = pr.pull_request_id
 
 
     message_len = len(messages)


### PR DESCRIPTION
The below PR contents are lightly modified (to adjust issue and PR references mostly) from github.com/augurlabs/augur/pull/3444, filed by @predictivemanish. The PR itself has been rebased to account for changes to CollectOSS since the fork and resolve merge conflicts

**Description**

Moved mapping queries outside batch loops and pass pre-built mappings as parameters to processing functions, following the pattern established by Shlok in https://github.com/augurlabs/augur/pull/3439. 
### Changes Made

#### `collectoss/tasks/github/messages.py`
- Built `issue_url_to_id_map` and `pr_issue_url_to_id_map` once in `collect_github_messages()` before any batch processing
- Updated `process_messages()` to accept mappings as parameters instead of rebuilding them
- Updated `process_large_issue_and_pr_message_collection()` to accept and pass mappings
- Increased batch size from 20 to 1000 (reduces batch overhead)

#### `collectoss/tasks/github/events.py`
- Built `issue_url_to_id_map` and `pr_url_to_id_map` once in `BulkGithubEventCollection.collect()` before the batch loop
- Updated `_process_events()`, `_process_issue_events()`, and `_process_pr_events()` to accept mappings as parameters
- Removed redundant `_get_map_from_*()` calls from batch processing methods

## Performance Improvement

- Before: 1,000 messages -> 50 full scans of issues AND PRs tables
- After: 1,000 messages -> 1 full scan of each table (50x reduction)

- Before: 10,000 events -> 40 full scans total
- After: 10,000 events → 1 full scan of each table (40x reduction)

This PR fixes #146 

**Notes for Reviewers**

**Signed commits**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/collectoss/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->