### PR TITLE
fix: skip PR review comment collection when pull requests are disabled

### DIFF
--- a/collectoss/tasks/github/pull_requests/tasks.py
+++ b/collectoss/tasks/github/pull_requests/tasks.py
@@ -227,22 +227,30 @@ def collect_pull_request_review_comments(repo_git: str, full_collection: bool) -
     """
     owner, repo = get_owner_repo(repo_git)
 
-    review_msg_url = f"https://api.github.com/repos/{owner}/{repo}/pulls/comments"
-
     logger = logging.getLogger(collect_pull_request_review_comments.__name__)
     logger.debug(f"Collecting pull request review comments for {owner}/{repo}")
 
+    key_auth = GithubRandomKeyAuth(logger)
+    github_data_access = GithubDataAccess(key_auth, logger)
+
+    if not github_data_access.check_prs_enabled(owner, repo):
+        logger.info(f"{owner}/{repo}: Pull requests appear to be disabled for this repo. Skipping review comment collection.")
+        return
+
     repo_id = get_repo_by_repo_git(repo_git).repo_id
 
+    search_args = {}
     if not full_collection:
         last_collected_date = get_secondary_data_last_collected(repo_id)
 
         if last_collected_date:
             # Subtract 2 days to ensure all data is collected
             core_data_last_collected = (last_collected_date - timedelta(days=2)).replace(tzinfo=timezone.utc)
-            review_msg_url += f"?since={core_data_last_collected.isoformat()}"
+            search_args["since"] = core_data_last_collected.isoformat()
         else:
             logger.warning(f"core_data_last_collected is NULL for recollection on repo: {repo_git}")
+
+    review_msg_url = github_data_access.endpoint_url(f"repos/{owner}/{repo}/pulls/comments", search_args or None)
 
     pr_reviews = get_pull_request_reviews_by_repo_id(repo_id)
 
@@ -256,9 +264,6 @@ def collect_pull_request_review_comments(repo_git: str, full_collection: bool) -
     tool_source = "Pr review comment task"
     tool_version = "2.0"
     data_source = "Github API"
-
-    key_auth = GithubRandomKeyAuth(logger)
-    github_data_access = GithubDataAccess(key_auth, logger)
 
     pr_review_comment_batch_size = get_batch_size()
 


### PR DESCRIPTION
The below PR contents are lightly modified (to adjust issue and PR references mostly) from github.com/augurlabs/augur/pull/3745, filed by @mn-ram. The PR itself has been rebased to account for changes to CollectOSS since the fork (there were effectively no merge conflicts)

## Description

Builds on https://github.com/augurlabs/augur/pull/3783 which added the `check_prs_enabled()` infrastructure and applied it to `retrieve_all_pr_data`.

This PR applies the same check to `collect_pull_request_review_comments`, which hits the `repos/{owner}/{repo}/pulls/comments` endpoint. This endpoint also returns 404 when pull requests are disabled on a repo, and previously had no handling for that case — causing an unhandled exception in the secondary collection phase.

**Changes:**
- Call `check_prs_enabled()` early in `collect_pull_request_review_comments` and return gracefully if PRs are disabled
- Move `GithubRandomKeyAuth` and `GithubDataAccess` instantiation before the check
- Migrate URL construction to use `GithubDataAccess.endpoint_url()` following the pattern from `retrieve_all_pr_data`

## Testing

- [ ] Manually add a repo with GitHub pull requests disabled and confirm `collect_pull_request_review_comments` logs an info message and returns without error

## Signed commits
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects!

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will be accelerated and your PR merged more quickly.
-->