### PR TITLE
Fix RabbitMQ runtime credentials

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,10 +44,10 @@ services:
     build:
       context: .
       dockerfile: ./docker/rabbitmq/Dockerfile
-      args:
-        - RABBIT_MQ_DEFAULT_USER=${COLLECTOSS_RABBITMQ_USERNAME:-augur}
-        - RABBIT_MQ_DEFAULT_PASSWORD=${COLLECTOSS_RABBITMQ_PASSWORD:-password123}
-        - RABBIT_MQ_DEFAULT_VHOST=${COLLECTOSS_RABBITMQ_VHOST:-collectoss_vhost}
+    environment:
+      - RABBIT_MQ_DEFAULT_USER=${COLLECTOSS_RABBITMQ_USERNAME:-augur}
+      - RABBIT_MQ_DEFAULT_PASSWORD=${COLLECTOSS_RABBITMQ_PASSWORD:-password123}
+      - RABBIT_MQ_DEFAULT_VHOST=${COLLECTOSS_RABBITMQ_VHOST:-collectoss_vhost}
 
   core:
     image: collectoss:latest

--- a/docker/rabbitmq/Dockerfile
+++ b/docker/rabbitmq/Dockerfile
@@ -21,9 +21,5 @@ RUN apk add --no-cache python3
 COPY docker/rabbitmq/update_config.py /
 COPY docker/rabbitmq/docker-entrypoint.sh /collectoss-rabbitmq-entrypoint.sh
 
-RUN chmod +x /collectoss-rabbitmq-entrypoint.sh
-
-RUN chown rabbitmq:rabbitmq /etc/rabbitmq/definitions.json
-
-ENTRYPOINT ["/collectoss-rabbitmq-entrypoint.sh"]
+ENTRYPOINT ["/bin/sh", "/collectoss-rabbitmq-entrypoint.sh"]
 CMD ["rabbitmq-server"]

--- a/docker/rabbitmq/Dockerfile
+++ b/docker/rabbitmq/Dockerfile
@@ -8,13 +8,9 @@ LABEL org.opencontainers.image.documentation="https://docs.collectoss.org"
 ARG VERSION
 LABEL org.opencontainers.image.version=${VERSION}
 
-ARG RABBIT_MQ_DEFAULT_USER=augur
-ARG RABBIT_MQ_DEFAULT_PASSWORD=password123
-ARG RABBIT_MQ_DEFAULT_VHOST=collectoss_vhost
-
 COPY --chown=rabbitmq:rabbitmq ./docker/rabbitmq/collectoss.conf /etc/rabbitmq/conf.d/
 
-ADD docker/rabbitmq/definitions.json /etc/rabbitmq/
+COPY --chown=rabbitmq:rabbitmq docker/rabbitmq/definitions.json /etc/rabbitmq/
 
 ADD docker/rabbitmq/advanced.config /etc/rabbitmq/
 RUN chown rabbitmq:rabbitmq /etc/rabbitmq/advanced.config
@@ -23,7 +19,11 @@ RUN chmod 777 /etc/rabbitmq/conf.d/collectoss.conf
 
 RUN apk add --no-cache python3
 COPY docker/rabbitmq/update_config.py /
+COPY docker/rabbitmq/docker-entrypoint.sh /collectoss-rabbitmq-entrypoint.sh
 
-RUN exec python3 update_config.py
+RUN chmod +x /collectoss-rabbitmq-entrypoint.sh
 
 RUN chown rabbitmq:rabbitmq /etc/rabbitmq/definitions.json
+
+ENTRYPOINT ["/collectoss-rabbitmq-entrypoint.sh"]
+CMD ["rabbitmq-server"]

--- a/docker/rabbitmq/docker-entrypoint.sh
+++ b/docker/rabbitmq/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+python3 /update_config.py
+exec /usr/local/bin/docker-entrypoint.sh "$@"

--- a/docker/rabbitmq/update_config.py
+++ b/docker/rabbitmq/update_config.py
@@ -1,17 +1,27 @@
 from os import environ as env
-import json, subprocess
+import json
+import subprocess
 from pathlib import Path
 
-rabbit_user = env.get("RABBIT_MQ_DEFAULT_USER")
-rabbit_pass = env.get("RABBIT_MQ_DEFAULT_PASSWORD")
-rabbit_vhost = env.get("RABBIT_MQ_DEFAULT_VHOST")
+
+def get_env(*names):
+    for name in names:
+        value = env.get(name)
+        if value:
+            return value
+    return None
+
+
+rabbit_user = get_env("RABBITMQ_DEFAULT_USER", "RABBIT_MQ_DEFAULT_USER")
+rabbit_pass = get_env("RABBITMQ_DEFAULT_PASS", "RABBIT_MQ_DEFAULT_PASSWORD")
+rabbit_vhost = get_env("RABBITMQ_DEFAULT_VHOST", "RABBIT_MQ_DEFAULT_VHOST")
 
 if not rabbit_user:
     raise ValueError("No default user set")
 
 if not rabbit_pass:
     raise ValueError("No default password set")
-    
+
 if not rabbit_vhost:
     raise ValueError("No default vhost set")
 
@@ -20,9 +30,11 @@ config_file = Path("/etc/rabbitmq/definitions.json")
 with config_file.open() as file:
     config = json.load(file)
 
-hash_processor = subprocess.run(f"rabbitmqctl hash_password {rabbit_pass}".split(),
-                                text=True,
-                                stdout=subprocess.PIPE)
+hash_processor = subprocess.run(
+    ["rabbitmqctl", "hash_password", rabbit_pass],
+    text=True,
+    stdout=subprocess.PIPE,
+)
 
 if hash_processor.returncode != 0:
     raise Exception("Could not calculate password hash")


### PR DESCRIPTION
Change rabbit mq variables from build time to runtime by changing it from args to environment variables
Fix issue #278 