### PR TITLE
Improvements to masking of API keys in error messages

### DIFF
--- a/collectoss/tasks/github/util/github_data_access.py
+++ b/collectoss/tasks/github/util/github_data_access.py
@@ -169,7 +169,7 @@ class GithubDataAccess:
                 raise UrlNotFoundException(f"Could not find {url}")
             
             if response.status_code == 401:
-                raise NotAuthorizedException(f"Could not authorize with the github api")
+                raise NotAuthorizedException(f"Could not authorize with the github api using key: {mask_key(self.key)}")
             
             if response.status_code == 410:
                 response_msg = response.json().get("message")

--- a/collectoss/util/keys.py
+++ b/collectoss/util/keys.py
@@ -1,5 +1,7 @@
 def mask_key(key: str, first: int = 6, last: int = 3, stars: int = 6) -> str:
     """Mask key except for the first and last few characters."""
+    if key is None:
+        return None
     if not isinstance(key, str) or len(key) <= (first + last):
-        return "*" * stars
+        return ("*" * stars) + str(type(key))
     return f"{key[:first]}{'*' * stars}{key[-last:]}"

--- a/collectoss/util/keys.py
+++ b/collectoss/util/keys.py
@@ -8,4 +8,4 @@ def mask_key(key: str, first: int = 6, last: int = 3, stars: int = 6) -> str:
             return "*" * stars
         return f"{key[:first]}{'*' * stars}{key[-last:]}"
     else:
-        return ("*" * stars) + str(type(key))
+        return "*" * stars + f" Type: {str(type(key))}"

--- a/collectoss/util/keys.py
+++ b/collectoss/util/keys.py
@@ -4,6 +4,8 @@ def mask_key(key: str, first: int = 6, last: int = 3, stars: int = 6) -> str:
         return None
 
     if isinstance(key, str):
+        if key == "":
+            return "*" * stars + f" Type: empty string"
         if len(key) <= (first + last):
             return "*" * stars
         return f"{key[:first]}{'*' * stars}{key[-last:]}"

--- a/collectoss/util/keys.py
+++ b/collectoss/util/keys.py
@@ -2,6 +2,10 @@ def mask_key(key: str, first: int = 6, last: int = 3, stars: int = 6) -> str:
     """Mask key except for the first and last few characters."""
     if key is None:
         return None
-    if not isinstance(key, str) or len(key) <= (first + last):
+
+    if isinstance(key, str):
+        if len(key) <= (first + last):
+            return "*" * stars
+        return f"{key[:first]}{'*' * stars}{key[-last:]}"
+    else:
         return ("*" * stars) + str(type(key))
-    return f"{key[:first]}{'*' * stars}{key[-last:]}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,7 @@ testpaths = [
     "tests/test_application/test_cli/test_csv_utils.py",
     "tests/test_tasks/test_task_utilities/test_util/",
     "tests/test_application/test_db/test_timestamp_utils.py",
+    "tests/test_util/test_keys.py",
     # "tests/test_routes", # runs, but needs a fixture for connecting to the web interface of Augur
     # "tests/test_metrics",
     # "tests/test_tasks",

--- a/tests/test_util/test_keys.py
+++ b/tests/test_util/test_keys.py
@@ -1,0 +1,56 @@
+import pytest
+
+from collectoss.util.keys import mask_key
+
+
+def test_none():
+    assert mask_key(None) is None
+
+def test_empty_string():
+    assert mask_key("") == "*" * 6 + " Type: empty string"
+
+def test_non_string():
+    result = mask_key(12345)
+    assert "*" in result
+    assert str(type(12345)) in result
+
+
+def test_non_string_list():
+    result = mask_key([1, 2, 3])
+    assert "*" in result
+    assert str(type([])) in result
+
+
+def test_short_string():
+    assert mask_key("short") == f"******"
+
+
+def test_long_string_masked_correctly():
+    key = "ghp_abcdefghij"  # 14 chars → first 6 + 6 stars + last 3
+    assert mask_key(key) == "ghp_ab******hij"
+
+
+def test_exactly_one_over_boundary():
+    # 10 chars: first 6 + 6 stars + last 3
+    key = "1234567890"
+    assert mask_key(key) == "123456******890"
+
+
+def test_default_star_count_is_six():
+    key = "abcdefghijk"  # 11 chars
+    result = mask_key(key)
+    middle = result[6:-3]
+    assert middle == "******"
+
+
+def test_custom_first_last_stars():
+    # first=2, last=2, stars=3 → boundary=4; "hello" is 5 chars → masked
+    assert mask_key("hello", first=2, last=2, stars=3) == "he***lo"
+
+
+def test_custom_stars_count_in_output():
+    key = "abcdefghijk"
+    result = mask_key(key, stars=10)
+    assert result == "abcdef**********ijk"
+
+


### PR DESCRIPTION
**Description**
This PR adds a (masked) printout of the affected API key in the `raise NotAuthorizedException(f"Could not authorize with the github api")` line to help deal with current facade issues in 1.1RC1.

It also makes a few improvements to make the masked keys more useful for debugging (by including a type when the keys are not strings, and being clear about when the keys are None or empty string.

**Notes for Reviewers**
This PR includes unit tests and can be merged when those tests pass.


**Signed commits**
- [X] Yes, I signed my commits.


**Generative AI disclosure**
<!-- To learn more about our Generative AI policy and required disclosures, see the `CONTRIBUTING.md` file -->

Please select one option:

- [ ] This contribution was NOT assisted or created by Generative AI tools.
- [X] This contribution was assisted or created by Generative AI tools.


If AI tools were used, please provide details below:
    - What tools were used? Sonnet 4.6 medium via cursor
    - How were these tools used? AI was used to write a first pass of the unit tests.
    - Did you review these outputs before submitting this PR? yes, the unit tests (and all code changes here) were reviewed, corrected, and tested by me.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/collectoss/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->