### PR TITLE
Attempt to fix bottlenecks and performance related to Facade

### DIFF
--- a/collectoss/tasks/start_tasks.py
+++ b/collectoss/tasks/start_tasks.py
@@ -254,12 +254,13 @@ def collection_monitor(self):
     logger.info("Checking for repos to collect")
 
     
-    #Get list of enabled phases 
-    enabled_phase_names = get_enabled_phase_names_from_config(engine, logger)
-
+    
     enabled_collection_hooks = []
 
     with DatabaseSession(logger, engine) as session:
+
+        #Get list of enabled phases 
+        enabled_phase_names = get_enabled_phase_names_from_config_session(session, logger)
 
         # Get config values for collection intervals
         config = SystemConfig(logger, session)
@@ -344,6 +345,12 @@ def retry_errored_repos(self):
     """
     engine = self.app.engine
     logger = logging.getLogger(create_collection_status_records.__name__)
+
+
+
+    with DatabaseSession(logger, engine) as session:
+            # get_newly_added_repos(session, logger, enabled_phase_names, days_until_collect_again = 1)
+
 
     #TODO: Isaac needs to normalize the status's to be abstract in the 
     #collection_status table once collectoss dev is less unstable dev is less unstable.

--- a/collectoss/tasks/start_tasks.py
+++ b/collectoss/tasks/start_tasks.py
@@ -259,7 +259,7 @@ def collection_monitor(self):
 
     enabled_collection_hooks = []
 
-    with DatabaseSession(logger, self.app.engine) as session:
+    with DatabaseSession(logger, engine) as session:
 
         # Get config values for collection intervals
         config = SystemConfig(logger, session)

--- a/collectoss/tasks/start_tasks.py
+++ b/collectoss/tasks/start_tasks.py
@@ -367,28 +367,32 @@ def retry_errored_repos(self):
         if machine_learning_phase.__name__ in enabled_phase_names:
             total_new_repos += len(get_newly_added_repos(session, logger, "ml"))
 
-    #TODO: Isaac needs to normalize the status's to be abstract in the 
-    #collection_status table once collectoss dev is less unstable dev is less unstable.
-    query = s.sql.text(f"""UPDATE collection_status SET secondary_status = '{CollectionState.PENDING.value}'"""
-    f""" WHERE secondary_status = '{CollectionState.ERROR.value}' and secondary_data_last_collected is NULL;"""
-    f"""UPDATE collection_status SET core_status = '{CollectionState.PENDING.value}'"""
-    f""" WHERE core_status = '{CollectionState.ERROR.value}' and core_data_last_collected is NULL;"""
-    f"""UPDATE collection_status SET facade_status = '{CollectionState.PENDING.value}'"""
-    f""" WHERE facade_status = '{CollectionState.ERROR.value}' and facade_data_last_collected is NULL;"""
-    f"""UPDATE collection_status SET ml_status = '{CollectionState.PENDING.value}'"""
-    f""" WHERE ml_status = '{CollectionState.ERROR.value}' and ml_data_last_collected is NULL;"""
-    
-    f"""UPDATE collection_status SET secondary_status = '{CollectionState.SUCCESS.value}'"""
-    f""" WHERE secondary_status = '{CollectionState.ERROR.value}' and secondary_data_last_collected is not NULL;"""
-    f"""UPDATE collection_status SET core_status = '{CollectionState.SUCCESS.value}'"""
-    f""" WHERE core_status = '{CollectionState.ERROR.value}' and core_data_last_collected is not NULL;"""
-    f"""UPDATE collection_status SET facade_status = '{CollectionState.SUCCESS.value}'"""
-    f""" WHERE facade_status = '{CollectionState.ERROR.value}' and facade_data_last_collected is not NULL;"""
-    f"""UPDATE collection_status SET ml_status = '{CollectionState.SUCCESS.value}'"""
-    f""" WHERE ml_status = '{CollectionState.ERROR.value}' and ml_data_last_collected is not NULL;"""
-    )
+    if total_new_repos == 0:
 
-    execute_sql(query)
+        #TODO: Isaac needs to normalize the status's to be abstract in the 
+        #collection_status table once collectoss dev is less unstable dev is less unstable.
+        query = s.sql.text(f"""UPDATE collection_status SET secondary_status = '{CollectionState.PENDING.value}'"""
+        f""" WHERE secondary_status = '{CollectionState.ERROR.value}' and secondary_data_last_collected is NULL;"""
+        f"""UPDATE collection_status SET core_status = '{CollectionState.PENDING.value}'"""
+        f""" WHERE core_status = '{CollectionState.ERROR.value}' and core_data_last_collected is NULL;"""
+        f"""UPDATE collection_status SET facade_status = '{CollectionState.PENDING.value}'"""
+        f""" WHERE facade_status = '{CollectionState.ERROR.value}' and facade_data_last_collected is NULL;"""
+        f"""UPDATE collection_status SET ml_status = '{CollectionState.PENDING.value}'"""
+        f""" WHERE ml_status = '{CollectionState.ERROR.value}' and ml_data_last_collected is NULL;"""
+        
+        f"""UPDATE collection_status SET secondary_status = '{CollectionState.SUCCESS.value}'"""
+        f""" WHERE secondary_status = '{CollectionState.ERROR.value}' and secondary_data_last_collected is not NULL;"""
+        f"""UPDATE collection_status SET core_status = '{CollectionState.SUCCESS.value}'"""
+        f""" WHERE core_status = '{CollectionState.ERROR.value}' and core_data_last_collected is not NULL;"""
+        f"""UPDATE collection_status SET facade_status = '{CollectionState.SUCCESS.value}'"""
+        f""" WHERE facade_status = '{CollectionState.ERROR.value}' and facade_data_last_collected is not NULL;"""
+        f"""UPDATE collection_status SET ml_status = '{CollectionState.SUCCESS.value}'"""
+        f""" WHERE ml_status = '{CollectionState.ERROR.value}' and ml_data_last_collected is not NULL;"""
+        )
+
+        execute_sql(query)
+    else:
+        logger.warning(f"Skipping retry of errored repos so we dont overwhelm collection when there are {total_new_repos} new repos to collect")
 
 
 

--- a/collectoss/tasks/start_tasks.py
+++ b/collectoss/tasks/start_tasks.py
@@ -347,10 +347,25 @@ def retry_errored_repos(self):
     logger = logging.getLogger(create_collection_status_records.__name__)
 
 
-
     with DatabaseSession(logger, engine) as session:
-            # get_newly_added_repos(session, logger, enabled_phase_names, days_until_collect_again = 1)
 
+        # if we have a lot of new repos to collect, we should skip retrying repos that have errored until collection is caught up.
+        total_new_repos = 0
+
+        #Get list of enabled phases 
+        enabled_phase_names = get_enabled_phase_names_from_config_session(session, logger)
+
+        if primary_repo_collect_phase.__name__ in enabled_phase_names:
+            total_new_repos += len(get_newly_added_repos(session, logger, "core"))
+    
+        if secondary_repo_collect_phase.__name__ in enabled_phase_names:
+            total_new_repos += len(get_newly_added_repos(session, logger, "secondary"))
+
+        if facade_phase.__name__ in enabled_phase_names:
+            total_new_repos += len(get_newly_added_repos(session, logger, "facade"))
+
+        if machine_learning_phase.__name__ in enabled_phase_names:
+            total_new_repos += len(get_newly_added_repos(session, logger, "ml"))
 
     #TODO: Isaac needs to normalize the status's to be abstract in the 
     #collection_status table once collectoss dev is less unstable dev is less unstable.

--- a/collectoss/tasks/start_tasks.py
+++ b/collectoss/tasks/start_tasks.py
@@ -366,7 +366,7 @@ def retry_errored_repos(self):
         if facade_phase.__name__ in enabled_phase_names:
             total_new_repos += len(get_newly_added_repos(session, query_limit, "facade"))
 
-        if machine_learning_phase.__name__ in enabled_phase_names:
+        if not RUNNING_DOCKER and machine_learning_phase.__name__ in enabled_phase_names:
             total_new_repos += len(get_newly_added_repos(session, query_limit, "ml"))
 
     if total_new_repos == 0:

--- a/collectoss/tasks/start_tasks.py
+++ b/collectoss/tasks/start_tasks.py
@@ -359,11 +359,11 @@ def retry_errored_repos(self):
     f"""UPDATE collection_status SET secondary_status = '{CollectionState.SUCCESS.value}'"""
     f""" WHERE secondary_status = '{CollectionState.ERROR.value}' and secondary_data_last_collected is not NULL;"""
     f"""UPDATE collection_status SET core_status = '{CollectionState.SUCCESS.value}'"""
-    f""" WHERE core_status = '{CollectionState.ERROR.value}' and core_data_last_collected is not NULL;;"""
+    f""" WHERE core_status = '{CollectionState.ERROR.value}' and core_data_last_collected is not NULL;"""
     f"""UPDATE collection_status SET facade_status = '{CollectionState.SUCCESS.value}'"""
-    f""" WHERE facade_status = '{CollectionState.ERROR.value}' and facade_data_last_collected is not NULL;;"""
+    f""" WHERE facade_status = '{CollectionState.ERROR.value}' and facade_data_last_collected is not NULL;"""
     f"""UPDATE collection_status SET ml_status = '{CollectionState.SUCCESS.value}'"""
-    f""" WHERE ml_status = '{CollectionState.ERROR.value}' and ml_data_last_collected is not NULL;;"""
+    f""" WHERE ml_status = '{CollectionState.ERROR.value}' and ml_data_last_collected is not NULL;"""
     )
 
     execute_sql(query)

--- a/collectoss/tasks/start_tasks.py
+++ b/collectoss/tasks/start_tasks.py
@@ -355,17 +355,19 @@ def retry_errored_repos(self):
         #Get list of enabled phases 
         enabled_phase_names = get_enabled_phase_names_from_config_session(session, logger)
 
+        query_limit = 1_000_000
+
         if primary_repo_collect_phase.__name__ in enabled_phase_names:
-            total_new_repos += len(get_newly_added_repos(session, logger, "core"))
+            total_new_repos += len(get_newly_added_repos(session, query_limit, "core"))
     
         if secondary_repo_collect_phase.__name__ in enabled_phase_names:
-            total_new_repos += len(get_newly_added_repos(session, logger, "secondary"))
+            total_new_repos += len(get_newly_added_repos(session, query_limit, "secondary"))
 
         if facade_phase.__name__ in enabled_phase_names:
-            total_new_repos += len(get_newly_added_repos(session, logger, "facade"))
+            total_new_repos += len(get_newly_added_repos(session, query_limit, "facade"))
 
         if machine_learning_phase.__name__ in enabled_phase_names:
-            total_new_repos += len(get_newly_added_repos(session, logger, "ml"))
+            total_new_repos += len(get_newly_added_repos(session, query_limit, "ml"))
 
     if total_new_repos == 0:
 

--- a/collectoss/tasks/util/collection_util.py
+++ b/collectoss/tasks/util/collection_util.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import logging
 import random
 import datetime
+import math
 #from celery.result import AsyncResult
 from celery import chain
 import sqlalchemy as s
@@ -43,7 +44,11 @@ class CollectionRequest:
         if limit <= 0:
             return
 
-        new_collection_git_list = get_newly_added_repos(session, limit, hook=self.name)
+        # fill the remaining limit with half new repos and half recollected repos
+        # favoring recollection if there isnt an even number of repos
+        new_collection_limit = math.floor(limit / 2)        
+
+        new_collection_git_list = get_newly_added_repos(session, new_collection_limit, hook=self.name)
         collection_list = [(repo_git, True) for repo_git in new_collection_git_list]
         self.repo_list.extend(collection_list)
         limit -= len(collection_list)


### PR DESCRIPTION
**Description**
This PR attempts to fix a couple non-normal conditions with regard to facade.

1. An instance that adds a lot of new repos at once can see existing repo recollections fall behind the configured window (because new repo collection currently takes priority)
2. an instance with a lot of repos that have collection errors can become severely bottlenecked and have keys potentially exhausted when ALL errored repos are reset to non-error states once a day by the error retry task.

These two issues can combine to grind collection to a halt and waste significant resources.

This PR addresses these issues by:
1. reserving half (or slightly less than half) of available collection slots for new collection (if needed), ensuring recollection jobs still have a path through the pipeline.
2. adjusting the error retry task so that it only resets errored repos when there are no new repos to collect.

when the errored repos (possibly a lot of them) get their status reset all at once, it causes a flood of collection tasks that are likely to fail again, thus potentially eating up API key usage when it might be needed for large tasks like new collection, contributing to slowness or bottlenecks.

This PR fixes #391 

**Notes for Reviewers**

I still have yet to test this fully. itll probably be complicated to test

**Signed commits**
- [X] Yes, I signed my commits.


**Generative AI disclosure**
<!-- To learn more about our Generative AI policy and required disclosures, see the `CONTRIBUTING.md` file -->

Please select one option:

- [ ] This contribution was NOT assisted or created by Generative AI tools.
- [X] This contribution was assisted or created by Generative AI tools.


If AI tools were used, please provide details below:
    - What tools were used? Sonnet 4.6 Medium via Cursor
    - How were these tools used? lots of back and forth to attempt to diagnose the general collection performance issues. Some AI code completion was used to write the code
    - Did you review these outputs before submitting this PR? Yes, at all times I was making sure the AI tool's diagnosis was sensible given my knowledge of the code and all written code was looked at and understood by me.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
3. Build and test your changes before submitting a PR. 
4. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/collectoss/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->