### PR TITLE
Batch SCC repo_labor inserts to reduce occurrence of massive log lines

### DIFF
--- a/collectoss/tasks/git/scc_value_tasks/core.py
+++ b/collectoss/tasks/git/scc_value_tasks/core.py
@@ -26,7 +26,6 @@ def value_model(logger,repo_git):
     required_output = parse_json_from_subprocess_call(logger,['./scc', '-f','json','--by-file', path], cwd=path_to_scc)
     
     logger.info('adding scc data to database... ')
-    logger.debug(f"output: {required_output}")
 
     to_insert = []
     for record in required_output:

--- a/collectoss/tasks/git/scc_value_tasks/core.py
+++ b/collectoss/tasks/git/scc_value_tasks/core.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 import os
 from collectoss.application.db.models import *
-from collectoss.application.db.lib import bulk_insert_dicts, get_repo_by_repo_git, get_value
+from collectoss.application.db.lib import bulk_insert_dicts, get_repo_by_repo_git, get_value, get_batch_size
 from collectoss.application.environment import SystemEnv
 from collectoss.tasks.util.worker_util import parse_json_from_subprocess_call
 from collectoss.tasks.git.util.facade_worker.facade_worker.utilitymethods import get_absolute_repo_path
@@ -27,9 +27,19 @@ def value_model(logger,repo_git):
     
     logger.info('adding scc data to database... ')
 
+    total_records = 0
+    scc_batch_size = get_batch_size("scc")
     to_insert = []
     for record in required_output:
         for file in record['Files']:
+
+            if len(to_insert) >= scc_batch_size:
+                
+                logger.info(f"{repo_git}: Processing batch of {len(to_insert)} scc records (total completed so far: {total_records})")
+                bulk_insert_dicts(logger, to_insert, RepoLabor, ["repo_id", "rl_analysis_date", "file_path", "file_name"])
+                total_records += len(to_insert)
+                to_insert.clear()
+
             repo_labor = {
                 'repo_id': repo_id,
                 'rl_analysis_date': datetime.now().strftime('%Y-%m-%dT%H:%M:%SZ'),
@@ -48,7 +58,11 @@ def value_model(logger,repo_git):
             }
 
             to_insert.append(repo_labor)
-    
-    bulk_insert_dicts(logger, to_insert, RepoLabor, ["repo_id", "rl_analysis_date", "file_path", "file_name" ])
+   
+    if len(to_insert) > 0:
+        logger.info(f"{repo_git}: Processing final batch of {len(to_insert)} scc records")
+        bulk_insert_dicts(logger, to_insert, RepoLabor, ["repo_id", "rl_analysis_date", "file_path", "file_name"])
+        total_records += len(to_insert)
+        to_insert.clear()
 
-    logger.info(f"Done generating scc data for repo {repo_id} from path {path}")
+    logger.info(f"Done generating scc data for repo {repo_id} from path {path}. Added {total_records} scc records")


### PR DESCRIPTION
**Description**
This removes a debug print statement and performs database insertions from scc in chunks using the configured chunk size (if available) or 1000 rows as a fallback.

This PR fixes #401 

**Notes for Reviewers**
Not yet extensively tested.

**Signed commits**
- [X] Yes, I signed my commits.


**Generative AI disclosure**
<!-- To learn more about our Generative AI policy and required disclosures, see the `CONTRIBUTING.md` file -->

Please select one option:

- [ ] This contribution was NOT assisted or created by Generative AI tools.
- [X] This contribution was assisted or created by Generative AI tools.


If AI tools were used, please provide details below:
    - What tools were used? Sonnet 4.6 Medium
    - How were these tools used? diagnosis and tracing the issue
    - Did you review these outputs before submitting this PR? only used for diagnosis. code was written by me by copying from other places in our code where we do similar batching.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/collectoss/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->