### PR TITLE
Fix github API handling and keyman behavior to correct handling of invalid or missing keys 

### DIFF
--- a/collectoss/tasks/github/util/github_data_access.py
+++ b/collectoss/tasks/github/util/github_data_access.py
@@ -174,6 +174,7 @@ class GithubDataAccess:
                 response_status = int(resp_content.get("status"))
 
                 if response_status == 401 and response_msg == "Bad credentials":
+                    self.logger.warning(f"Received a 401 response from github due to bad credential: {mask_key(self.key)}")
                     raise NotAuthorizedException(f"Could not authorize with the github api because key was invalid: {mask_key(self.key)}")
                 else:
                     self.logger.warning(f"Received a 401 response from github unrelated to bad credentials with message {response_msg}")

--- a/collectoss/tasks/github/util/github_data_access.py
+++ b/collectoss/tasks/github/util/github_data_access.py
@@ -206,7 +206,14 @@ class GithubDataAccess:
         try:
             return self.__make_request_with_retries(url, method, timeout)
         except RetryError as e:
-            raise e.last_attempt.exception()
+            last_exception = e.last_attempt.exception()
+
+            # https://github.com/orgs/community/discussions/101661#discussioncomment-8342211
+            # this suggests we should retry 401 exceptions at least once
+            if isinstance(last_exception, NotAuthorizedException):
+                self.expired_keys_for_request = []
+                self.__handle_github_not_authorized_response()           
+            raise last_exception
 
     def _decide_retry_policy(exception: Exception) -> bool:
         """Defines whether or not to retry a failed request based on the exception thrown
@@ -231,10 +238,6 @@ class GithubDataAccess:
             return result
         except RatelimitException as e:
             self.__handle_github_ratelimit_response(e.response)
-            raise e
-        except NotAuthorizedException as e:
-            self.expired_keys_for_request = []
-            self.__handle_github_not_authorized_response()
             raise e
 
     def __handle_github_not_authorized_response(self):

--- a/collectoss/tasks/github/util/github_data_access.py
+++ b/collectoss/tasks/github/util/github_data_access.py
@@ -169,7 +169,14 @@ class GithubDataAccess:
                 raise UrlNotFoundException(f"Could not find {url}")
             
             if response.status_code == 401:
-                raise NotAuthorizedException(f"Could not authorize with the github api using key: {mask_key(self.key)}")
+                resp_content = response.json()
+                response_msg = resp_content.get("message")
+                response_status = int(resp_content.get("status"))
+
+                if response_status == 401 and response_msg == "Bad credentials":
+                    raise NotAuthorizedException(f"Could not authorize with the github api because key was invalid: {mask_key(self.key)}")
+                else:
+                    self.logger.warning(f"Received a 401 response from github unrelated to bad credentials with message {response_msg}")
             
             if response.status_code == 410:
                 response_msg = response.json().get("message")

--- a/keyman/KeyClient.py
+++ b/keyman/KeyClient.py
@@ -104,7 +104,7 @@ class KeyClient:
             self._send("NEW", key_platform = platform or self.platform)
             try:
                 msg = self._recv()
-                if "key" in msg:
+                if msg.get("key") is not None:
                     return msg["key"]
                 raise Exception(f"Invalid response type: {msg}")
             except WaitKeyTimeout as e:

--- a/keyman/Orchestrator.py
+++ b/keyman/Orchestrator.py
@@ -156,7 +156,7 @@ class KeyOrchestrator:
         if not len(self.fresh_keys[platform]):
             if not len(self.expired_keys[platform]):
                 self.logger.warning(f"Key was requested for {platform}, but none are published")
-                return
+                raise WaitKeyTimeout(300)
 
             min_timeout = 0
             for _, timeout in self.expired_keys[platform].items():


### PR DESCRIPTION
**Description**
This PR is sort of a catch-all for a couple problems that I suspect were a large part of the cause behind #391

**Fix 1**: some none handling bugs in keyman
A couple small bugs related to handling of `None` values in the key handling (keyman) part of the code (improper condition and a bare `return` statement). Fixed the condition and changed the return to a WaitKeyException to request that the caller sleep for 5 minutes and try again later to see if theres any keys that have refreshed.

**Bug 2**: Improper handling of 401 HTTP errors in Github API code
The github REST API helper class (`GithubDataAccess`) was permanently invalidating a key upon receiving a 401 unauthorized response. This was despite the key in question still remaining valid when i manually checked it sometime later. My best guess is its an erroneous/transient error code from github. The way the code handled these errors is contrary to some [advice](https://github.com/orgs/community/discussions/101661#discussioncomment-8342211) i found online from a github employee suggesting that 401's should be retried a few times after a delay before treating the key as permanently invalidated. So the fix implemented for this is to move that invalidation step outside the retry loop, meaning we only invalidate a key if the unauthorized exception happens on the last retry (suggesting that the 9 prior retries also failed)

**Notes for Reviewers**
This has been tested repeatedly alongside #415 on a test instance and i dont believe there are issues with it

**Signed commits**
- [X] Yes, I signed my commits.


**Generative AI disclosure**
<!-- To learn more about our Generative AI policy and required disclosures, see the `CONTRIBUTING.md` file -->

Please select one option:

- [ ] This contribution was NOT assisted or created by Generative AI tools.
- [X] This contribution was assisted or created by Generative AI tools.


If AI tools were used, please provide details below:
    - What tools were used? Sonnet 4.6 Medium via cursor
    - How were these tools used? to the extent they were used at all (i dont remember), it would have been mainly for diagnosing the issue and maybe some incidental in-IDE code completion/helping.
    - Did you review these outputs before submitting this PR? yes. i maintained situational awareness and control over every code decision at all times.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/collectoss/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->