### PR TITLE
current time along with key expiry time

### DIFF
--- a/collectoss/application/cli/github.py
+++ b/collectoss/application/cli/github.py
@@ -52,6 +52,9 @@ def update_api_key():
 
             valid_key_data = sorted(valid_key_data, key=lambda x: x[1]["requests_remaining"])
 
+            current_time = epoch_to_local_time_with_am_pm(datetime.now().timestamp())
+            print(f"Current Time: {current_time.strip()}")
+            print("")
             core_request_header = "Core Requests Left"
             core_reset_header = "Core Reset Time"
             graphql_request_header = "Graphql Requests Left"


### PR DESCRIPTION
**Description**
Adds a "Current Time" line above the API key table in the `collectoss github api-keys` command output. This makes it easier to compare key reset times against the current time at a glance. Reuses the existing `epoch_to_local_time_with_am_pm()` helper so the format is consistent with the reset time column.

This PR fixes #412

**Notes for Reviewers**
3-line change in `collectoss/application/cli/github.py`. No new dependencies.

**Signed commits**
- [x] Yes, I signed my commits.

**Generative AI disclosure**

Please select one option:
- [ ] This contribution was NOT assisted or created by Generative AI tools.
- [x] This contribution was assisted or created by Generative AI tools.

If AI tools were used, please provide details below:
- What tools were used? Kiro
- How were these tools used? Drafted the code change
- Did you review these outputs before submitting this PR? Yes, reviewed and verified the change before submitting
