### PR TITLE
[tasks/github] Guard against None GraphQL response in collect_releases

### DIFF
--- a/collectoss/tasks/github/releases/core.py
+++ b/collectoss/tasks/github/releases/core.py
@@ -168,8 +168,16 @@ def fetch_data(key_auth, logger, github_url, repo_id, tag_only = False):
     logger.info("Hitting endpoint: {} ...\n".format(url))
     data = request_graphql_dict(key_auth,logger, url, query)
 
+    if data is None:
+        logger.warning(f"GraphQL returned None for repo {github_url}; skipping releases.")
+        return None
+
     if 'data' in data:
         data = data['data']['repository']
+
+    if data is None:
+        logger.warning(f"GraphQL repository node is None for repo {github_url}; skipping releases.")
+        return None
 
     data['owner'] = owner
 
@@ -181,6 +189,9 @@ def releases_model(session, key_auth, logger, repo_git, repo_id):
         data = fetch_data(key_auth, logger, repo_git, repo_id)
     except Exception as e:
         logger.info(f"Ran into problem when fetching data for repo {repo_git}: {e}")
+        return
+
+    if data is None:
         return
 
     #logger.info("repository value is: {}\n".format(data))
@@ -196,6 +207,8 @@ def releases_model(session, key_auth, logger, repo_git, repo_id):
         elif 'edges' in data['releases'] and not data['releases']['edges']:
             logger.info("Searching for tags instead of releases...")
             data = fetch_data(key_auth, logger, repo_git, repo_id,True)
+            if data is None:
+                return
             logger.info("refs value is: {}\n".format(data))
             if 'refs' in data:
                 if 'edges' in data['refs']:


### PR DESCRIPTION
This PR was originally filed as https://github.com/augurlabs/augur/pull/3722 by @devs6186

## Changeset
- Added None guard in `fetch_data()` in `releases/core.py` before the `'data' in data` check
- Added second None guard for the case where `data['data']['repository']` itself is None
- Guard the fallback `fetch_data(..., True)` call in `releases_model()` against a None return

## Notes
`request_graphql_dict()` can return None when the API call fails (network error, private repo, etc). Doing `if 'data' in data:` on a NoneType raises `TypeError: argument of type 'NoneType' is not iterable`, which was crashing the collect_releases task. The fix logs a warning and returns cleanly rather than propagating an exception.

The second None check (`data['data']['repository']` can be None if GitHub returns `{"data": {"repository": null}}` for a repo that no longer exists) prevents a similar crash further down.

## Related issues/PRs
- Fixes #225 

**Description**
- Added None checks in fetch_data() so collect_releases handles a None GraphQL response without crashing

This PR fixes #3709

**Notes for Reviewers**
Three small guard additions in the same file. No logic changes to the happy path.

**Signed commits**
- [x] Yes, I signed my commits.