### PR TITLE
Add per_page=100 to contributor breadth events API call

### DIFF
--- a/collectoss/tasks/data_analysis/contributor_breadth_worker/contributor_breadth_worker.py
+++ b/collectoss/tasks/data_analysis/contributor_breadth_worker/contributor_breadth_worker.py
@@ -92,7 +92,7 @@ def contributor_breadth_model(self) -> None:
         logger.info(f"Processing cntrb {index} of {total}")
         index += 1
 
-        repo_cntrb_url = f"https://api.github.com/users/{cntrb['gh_login']}/events"
+        repo_cntrb_url = f"https://api.github.com/users/{cntrb['gh_login']}/events?per_page=100"
 
         newest_event_in_db = datetime(1970, 1, 1)
         if cntrb["gh_login"] in cntrb_newest_events_map:


### PR DESCRIPTION
**Description**
The GitHub events API defaults to 30 results per page. This change adds
`?per_page=100` to the contributor events URL in the contributor breadth
worker, reducing the number of API calls by ~3x for the same data.

The `paginate_resource` method follows GitHub's `Link` header for
subsequent pages, so the `per_page` param is safely preserved across
all pages with no risk of conflicts.

This PR fixes #426

**Notes for Reviewers**
Single character change in `contributor_breadth_worker.py`. No logic changes.

**Signed commits**
- [x] Yes, I signed my commits.

**Generative AI disclosure**
- [x] This contribution was assisted or created by Generative AI tools.
- What tools were used? Kiro (Claude-based AI coding assistant)
- How were these tools used? Draft PR description.
- Did you review these outputs before submitting this PR? Yes
